### PR TITLE
Update Dagger using Dagger android components and view model factories

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.android.build.api.dsl.Packaging
-import org.jetbrains.kotlin.javac.resolve.MockKotlinField
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
@@ -65,13 +62,13 @@ android {
         }
     }
 
-
 }
 
 dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
@@ -88,7 +85,9 @@ dependencies {
 
     // Dagger
     implementation(libs.dagger)
+    implementation(libs.dagger.android)
     ksp(libs.dagger.compiler)
+    ksp(libs.dagger.compiler.android)
 
     // Data Store
     implementation(libs.androidx.datastore.preferences)
@@ -107,7 +106,6 @@ dependencies {
     androidTestImplementation(libs.mockk.android)
     testImplementation(libs.mockk)
 
-
     // Retrofit and okHttp
     implementation(libs.retrofit)
     implementation(libs.okhttp)
@@ -117,7 +115,6 @@ dependencies {
     implementation(libs.moshi)
     implementation(libs.moshi.kotlin)
     implementation(libs.converter.moshi)
-
 
     // Gson
     implementation(libs.gson)

--- a/app/src/main/java/com/sycosoft/allsee/AllSeeApplication.kt
+++ b/app/src/main/java/com/sycosoft/allsee/AllSeeApplication.kt
@@ -1,20 +1,13 @@
 package com.sycosoft.allsee
 
-import android.app.Application
-import com.sycosoft.allsee.di.components.ApplicationComponent
 import com.sycosoft.allsee.di.components.DaggerApplicationComponent
-import com.sycosoft.allsee.di.modules.ContextModule
+import dagger.android.AndroidInjector
+import dagger.android.DaggerApplication
 
-class AllSeeApplication : Application() {
-    lateinit var appComponent: ApplicationComponent
+class AllSeeApplication : DaggerApplication() {
 
-    override fun onCreate() {
-        super.onCreate()
-
-        appComponent = DaggerApplicationComponent
-            .builder()
-            .contextModule(ContextModule(this))
-            .build()
-    }
-
+    override fun applicationInjector(): AndroidInjector<out DaggerApplication> =
+        DaggerApplicationComponent
+            .factory()
+            .create(application = this)
 }

--- a/app/src/main/java/com/sycosoft/allsee/MainActivity.kt
+++ b/app/src/main/java/com/sycosoft/allsee/MainActivity.kt
@@ -5,6 +5,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.Surface
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.sycosoft.allsee.data.local.CryptoManager
 import com.sycosoft.allsee.data.local.TokenProvider
 import com.sycosoft.allsee.data.remote.services.StarlingBankApiService
@@ -12,29 +14,23 @@ import com.sycosoft.allsee.domain.repository.AppRepository
 import com.sycosoft.allsee.presentation.screens.AccountAccessPage
 import com.sycosoft.allsee.presentation.ui.theme.AllSeeTheme
 import com.sycosoft.allsee.presentation.viewmodels.AccountAccessPageViewModel
+import dagger.android.AndroidInjection
 import javax.inject.Inject
 
 class MainActivity : ComponentActivity() {
 
-    @Inject lateinit var appRepository: AppRepository
-
-    @Inject lateinit var cryptoManager: CryptoManager
-    @Inject lateinit var tokenProvider: TokenProvider
-    @Inject lateinit var starlingBankApiService: StarlingBankApiService
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
-
-        (application as AllSeeApplication).appComponent.inject(this)
 
         enableEdgeToEdge()
 
         setContent {
             AllSeeTheme {
                 Surface {
-                    AccountAccessPage(viewModel = AccountAccessPageViewModel(
-                        appRepository = appRepository,
-                    ))
+                    AccountAccessPage(viewModel = viewModel(factory = viewModelFactory))
                 }
             }
         }

--- a/app/src/main/java/com/sycosoft/allsee/di/components/ApplicationComponent.kt
+++ b/app/src/main/java/com/sycosoft/allsee/di/components/ApplicationComponent.kt
@@ -1,22 +1,35 @@
 package com.sycosoft.allsee.di.components
 
-import com.sycosoft.allsee.MainActivity
+import android.app.Application
+import com.sycosoft.allsee.AllSeeApplication
 import com.sycosoft.allsee.di.modules.ContextModule
 import com.sycosoft.allsee.di.modules.LocalModule
+import com.sycosoft.allsee.di.modules.MainActivityModule
 import com.sycosoft.allsee.di.modules.NetworkModule
 import com.sycosoft.allsee.di.modules.RepositoryModule
+import com.sycosoft.allsee.di.modules.ViewModelModule
+import dagger.BindsInstance
 import dagger.Component
+import dagger.android.AndroidInjectionModule
+import dagger.android.AndroidInjector
 import javax.inject.Singleton
 
 @Component(
     modules = [
+        AndroidInjectionModule::class,
         ContextModule::class,
         LocalModule::class,
         NetworkModule::class,
         RepositoryModule::class,
+        ViewModelModule::class,
+        MainActivityModule::class
     ]
 )
 @Singleton
-interface ApplicationComponent {
-    fun inject(mainActivity: MainActivity)
+interface ApplicationComponent : AndroidInjector<AllSeeApplication> {
+
+    @Component.Factory
+    interface Factory {
+        fun create(@BindsInstance application: Application): ApplicationComponent
+    }
 }

--- a/app/src/main/java/com/sycosoft/allsee/di/modules/ContextModule.kt
+++ b/app/src/main/java/com/sycosoft/allsee/di/modules/ContextModule.kt
@@ -7,12 +7,8 @@ import dagger.Provides
 import javax.inject.Singleton
 
 @Module
-class ContextModule(private val application: Application) {
+object ContextModule {
     @Provides
     @Singleton
-    fun provideApplicationContext(): Context = application.applicationContext
-
-    @Provides
-    @Singleton
-    fun provideApplication(): Application = application
+    fun provideApplicationContext(application: Application): Context = application.applicationContext
 }

--- a/app/src/main/java/com/sycosoft/allsee/di/modules/MainActivityModule.kt
+++ b/app/src/main/java/com/sycosoft/allsee/di/modules/MainActivityModule.kt
@@ -1,0 +1,13 @@
+package com.sycosoft.allsee.di.modules
+
+import com.sycosoft.allsee.MainActivity
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+
+
+@Module
+abstract class MainActivityModule {
+
+    @ContributesAndroidInjector
+    abstract fun activity(): MainActivity
+}

--- a/app/src/main/java/com/sycosoft/allsee/di/modules/ViewModelModule.kt
+++ b/app/src/main/java/com/sycosoft/allsee/di/modules/ViewModelModule.kt
@@ -1,0 +1,44 @@
+package com.sycosoft.allsee.di.modules
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.sycosoft.allsee.presentation.viewmodels.AccountAccessPageViewModel
+import dagger.Binds
+import dagger.MapKey
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import javax.inject.Provider
+import javax.inject.Singleton
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.reflect.KClass
+
+@Module
+abstract class ViewModelModule {
+
+    @MapKey
+    @Retention(RUNTIME)
+    annotation class ViewModelKey(val value: KClass<out ViewModel>)
+
+    companion object {
+
+        @Provides
+        @Singleton
+        fun viewModelFactory(
+            viewModels: Map<Class<out ViewModel>, @JvmSuppressWildcards Provider<ViewModel>>
+        ): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T =
+                    viewModels.entries
+                        .first { (key, _) -> modelClass.isAssignableFrom(key) }
+                        .value
+                        .get() as T
+            }
+    }
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(AccountAccessPageViewModel::class)
+    abstract fun bindAccountAccessPageViewModel(viewModel: AccountAccessPageViewModel): ViewModel
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
@@ -53,7 +54,9 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 
 # Dagger
 dagger = { module = "com.google.dagger:dagger", version.ref = "daggerCompiler" }
+dagger-android = { module = "com.google.dagger:dagger-android", version.ref = "daggerCompiler" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "daggerCompiler" }
+dagger-compiler-android = { module = "com.google.dagger:dagger-android-processor", version.ref = "daggerCompiler" }
 
 # Retrofit and OKHttp
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }


### PR DESCRIPTION
## Context

Pull request to update branch : `feature-implemented-dagger-and-extras`

## This PR

These changes are specifically for Dagger and Dagger Android.  Use Dagger Android specific features to help injection when using Android components.

## Code Changes

- Add dagger android dependencies to version catalogs
- Update application build gradle with updated dependencies
- Update `AllSeeApplication` to subclass `DaggerApplication`
- Update `ApplicationComponent` to subsclass `AndroidInjector<T>`
- Add `@Component.Factory` interface to assist creating component.
- Add `ViewModelModule`, including a generic `ViewModelProvider.Factory`
- Add `MainActivityModule` using `@ContributesAndroidInjector` to link to `AndroidInjection::inject`
- Update `MainActivity` to inject the `ViewModelProvider.Factory` and use `viewModel(factory = viewModelFactory)` to provide the view model.

## Screen shots

![Screenshot_20241112_191118](https://github.com/user-attachments/assets/d07792c9-368b-4a20-ba6a-8502f42c9b08)

