### PR TITLE
Feature/changed how name and account type is retrieved

### DIFF
--- a/app/src/main/java/com/sycosoft/allsee/data/remote/models/ErrorResponseDto.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/remote/models/ErrorResponseDto.kt
@@ -14,5 +14,3 @@ fun ErrorResponseDto.toDomain(): ErrorResponse = ErrorResponse(
     error = error,
     errorDescription = errorDescription,
 )
-
-// TODO: Add toDatabase mapper.

--- a/app/src/main/java/com/sycosoft/allsee/data/remote/models/IdentityDto.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/remote/models/IdentityDto.kt
@@ -1,0 +1,24 @@
+package com.sycosoft.allsee.data.remote.models
+
+import com.squareup.moshi.Json
+import com.sycosoft.allsee.domain.models.Identity
+import java.time.LocalDate
+
+/** Represents the identity of an account holder */
+data class IdentityDto(
+    @Json(name = "title") val title: String,
+    @Json(name = "firstName") val firstName: String,
+    @Json(name = "lastName") val lastName: String,
+    @Json(name = "dateOfBirth") val dateOfBirth: String,
+    @Json(name = "email") val email: String,
+    @Json(name = "phone") val phone: String,
+)
+
+fun IdentityDto.toDomain(): Identity = Identity(
+    title = title,
+    firstName = firstName,
+    lastName = lastName,
+    dob = LocalDate.parse(dateOfBirth),
+    email = email,
+    phone = phone,
+)

--- a/app/src/main/java/com/sycosoft/allsee/data/remote/services/StarlingBankApiService.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/remote/services/StarlingBankApiService.kt
@@ -3,6 +3,7 @@ package com.sycosoft.allsee.data.remote.services
 import com.sycosoft.allsee.data.remote.models.AccountHolderDto
 import com.sycosoft.allsee.data.remote.models.AccountHolderNameDto
 import com.sycosoft.allsee.data.remote.models.AccountListDto
+import com.sycosoft.allsee.data.remote.models.IdentityDto
 import retrofit2.http.GET
 
 
@@ -15,4 +16,7 @@ interface StarlingBankApiService {
 
     @GET("account-holder/name")
     suspend fun getAccountHolderName(): AccountHolderNameDto
+
+    @GET("identity/individual")
+    suspend fun getIdentity(): IdentityDto
 }

--- a/app/src/main/java/com/sycosoft/allsee/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/repository/AppRepositoryImpl.kt
@@ -9,7 +9,9 @@ import com.sycosoft.allsee.domain.exceptions.RepositoryException
 import com.sycosoft.allsee.domain.models.AccountHolder
 import com.sycosoft.allsee.domain.models.AccountHolderName
 import com.sycosoft.allsee.domain.models.ErrorResponse
+import com.sycosoft.allsee.domain.models.Identity
 import com.sycosoft.allsee.domain.models.NameAndAccountType
+import com.sycosoft.allsee.domain.models.Person
 import com.sycosoft.allsee.domain.repository.AppRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -50,6 +52,34 @@ class AppRepositoryImpl @Inject constructor(
                 type = type.await(),
             )
         }
+
+    @Throws(RepositoryException::class)
+    override suspend fun getIdentity(): Identity = try {
+        apiService.getIdentity().toDomain()
+    } catch(e: ApiException) {
+        throw throwRepositoryException(e)
+    }
+
+    @Throws(RepositoryException::class)
+    override suspend fun getPerson(): Person = try {
+        coroutineScope {
+            val accountHolder = async { getAccountHolder() }.await()
+            val identity = async { getIdentity() }.await()
+
+            Person(
+                uid = accountHolder.uid,
+                type = accountHolder.type,
+                title = identity.title,
+                firstName = identity.firstName,
+                lastName = identity.lastName,
+                dob = identity.dob,
+                email = identity.email,
+                phone = identity.phone,
+            )
+        }
+    } catch(e: ApiException) {
+        throw throwRepositoryException(e)
+    }
 
     private fun throwRepositoryException(e: ApiException): RepositoryException {
         Log.e(logTag, "error = ${e.errorResponse.error}, errorDescription = ${e.errorResponse.errorDescription}")

--- a/app/src/main/java/com/sycosoft/allsee/di/modules/UseCaseModule.kt
+++ b/app/src/main/java/com/sycosoft/allsee/di/modules/UseCaseModule.kt
@@ -4,6 +4,7 @@ import com.sycosoft.allsee.domain.repository.AppRepository
 import com.sycosoft.allsee.domain.usecases.GetAccountHolderNameUseCase
 import com.sycosoft.allsee.domain.usecases.GetAccountHolderUseCase
 import com.sycosoft.allsee.domain.usecases.GetNameAndAccountTypeUseCase
+import com.sycosoft.allsee.domain.usecases.GetPersonUseCase
 import com.sycosoft.allsee.domain.usecases.SaveTokenUseCase
 import dagger.Module
 import dagger.Provides
@@ -19,8 +20,12 @@ class UseCaseModule {
         GetAccountHolderUseCase(repository)
 
     @Provides
-    fun provideGetNameAndAccountTypeUseCase(repository: AppRepository): GetNameAndAccountTypeUseCase =
-        GetNameAndAccountTypeUseCase(repository)
+    fun provideGetNameAndAccountTypeUseCase(): GetNameAndAccountTypeUseCase =
+        GetNameAndAccountTypeUseCase()
+
+    @Provides
+    fun provideGetPersonUseCase(repository: AppRepository): GetPersonUseCase =
+        GetPersonUseCase(repository)
 
     @Provides
     fun provideSaveTokenUseCase(repository: AppRepository): SaveTokenUseCase =

--- a/app/src/main/java/com/sycosoft/allsee/domain/models/Identity.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/models/Identity.kt
@@ -1,0 +1,12 @@
+package com.sycosoft.allsee.domain.models
+
+import java.time.LocalDate
+
+data class Identity(
+    val title: String,
+    val firstName: String,
+    val lastName: String,
+    val dob: LocalDate,
+    val email: String,
+    val phone: String,
+)

--- a/app/src/main/java/com/sycosoft/allsee/domain/models/Person.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/models/Person.kt
@@ -1,0 +1,15 @@
+package com.sycosoft.allsee.domain.models
+
+import com.sycosoft.allsee.domain.models.types.AccountHolderType
+import java.time.LocalDate
+
+data class Person(
+    val uid: String,
+    val type: AccountHolderType,
+    val title: String,
+    val firstName: String,
+    val lastName: String,
+    val dob: LocalDate,
+    val email: String,
+    val phone: String,
+)

--- a/app/src/main/java/com/sycosoft/allsee/domain/repository/AppRepository.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/repository/AppRepository.kt
@@ -4,7 +4,9 @@ import com.sycosoft.allsee.data.local.TokenProvider
 import com.sycosoft.allsee.domain.exceptions.RepositoryException
 import com.sycosoft.allsee.domain.models.AccountHolder
 import com.sycosoft.allsee.domain.models.AccountHolderName
+import com.sycosoft.allsee.domain.models.Identity
 import com.sycosoft.allsee.domain.models.NameAndAccountType
+import com.sycosoft.allsee.domain.models.Person
 
 interface AppRepository {
     /** Encrypts the given token and then saves the result into the [TokenProvider] */
@@ -18,6 +20,13 @@ interface AppRepository {
     @Throws(RepositoryException::class)
     suspend fun getAccountHolder(): AccountHolder
 
+    /** Provides the name and account type of the current account holder */
     @Throws(RepositoryException::class)
     suspend fun getNameAndAccountType(): NameAndAccountType
+
+    @Throws(RepositoryException::class)
+    suspend fun getIdentity(): Identity
+
+    @Throws
+    suspend fun getPerson(): Person
 }

--- a/app/src/main/java/com/sycosoft/allsee/domain/repository/AppResult.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/repository/AppResult.kt
@@ -1,9 +1,0 @@
-package com.sycosoft.allsee.domain.repository
-
-import com.sycosoft.allsee.domain.models.ErrorResponse
-
-/** Represents the result from the app repository */
-sealed class AppResult<out T> {
-    data class Success<out T>(val data: T) : AppResult<T>()
-    data class Error(val errorResponse: ErrorResponse): AppResult<Nothing>()
-}

--- a/app/src/main/java/com/sycosoft/allsee/domain/usecases/GetNameAndAccountTypeUseCase.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/usecases/GetNameAndAccountTypeUseCase.kt
@@ -1,11 +1,8 @@
 package com.sycosoft.allsee.domain.usecases
 
 import com.sycosoft.allsee.domain.models.NameAndAccountType
-import com.sycosoft.allsee.domain.repository.AppRepository
-import javax.inject.Inject
+import com.sycosoft.allsee.domain.models.Person
 
-class GetNameAndAccountTypeUseCase @Inject constructor(
-    private val repository: AppRepository
-) {
-    suspend operator fun invoke(): NameAndAccountType = repository.getNameAndAccountType()
+class GetNameAndAccountTypeUseCase {
+    operator fun invoke(person: Person): NameAndAccountType = NameAndAccountType(name = person.firstName + " " + person.lastName, type = person.type.displayName)
 }

--- a/app/src/main/java/com/sycosoft/allsee/domain/usecases/GetPersonUseCase.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/usecases/GetPersonUseCase.kt
@@ -1,0 +1,11 @@
+package com.sycosoft.allsee.domain.usecases
+
+import com.sycosoft.allsee.domain.models.Person
+import com.sycosoft.allsee.domain.repository.AppRepository
+import javax.inject.Inject
+
+class GetPersonUseCase @Inject constructor(
+    private val repository: AppRepository,
+) {
+    suspend operator fun invoke(): Person = repository.getPerson()
+}

--- a/app/src/main/java/com/sycosoft/allsee/presentation/components/accountaccesspage/AccessTokenRequestScreen.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/components/accountaccesspage/AccessTokenRequestScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,21 +26,19 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sycosoft.allsee.R
 import com.sycosoft.allsee.domain.models.NameAndAccountType
-import com.sycosoft.allsee.presentation.components.Header1
-import com.sycosoft.allsee.presentation.components.Normal
 import com.sycosoft.allsee.presentation.theme.AllSeeTheme
-import com.sycosoft.allsee.presentation.theme.OffWhite
 import com.sycosoft.allsee.presentation.utils.UiState
 
 @Composable
 fun AccessTokenRequestScreen(
-    topSectionColor: Color = OffWhite,
+    topSectionColor: Color = MaterialTheme.colorScheme.inversePrimary,
     bottomSectionColor: Color = MaterialTheme.colorScheme.background,
     accessToken: String,
     onAccessTokenChange: (String) -> Unit,
     onGetStartedButtonClick: () -> Unit,
     uiState: UiState<NameAndAccountType>,
-    errorSnackbarCallback: @Composable (String) -> Unit,
+    errorSnackBarCallback: @Composable (String) -> Unit,
+    onOpenConfirmationDialog: (Boolean) -> Unit,
 ) {
 
     Box(
@@ -106,22 +103,18 @@ fun AccessTokenRequestScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            Header1(
+            Text(
                 modifier = Modifier
-                    .padding(bottom = 32.dp)
-                    .testTag("aap_title"),
+                    .testTag("aap_title")
+                    .padding(bottom = 32.dp),
                 text = stringResource(id = R.string.aap_title),
-                color = Color.Black,
+                style = MaterialTheme.typography.titleLarge,
             )
-            Normal(
+            Text(
                 modifier = Modifier.testTag("aap_text"),
-                text = stringResource(id = R.string.aap_get_started),
-                color = Color.Black,
+                text = stringResource(id = R.string.aap_get_started)
             )
             OutlinedTextField(
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedTextColor = Color.Black,
-                ),
                 modifier = Modifier
                     .padding(top = 16.dp, bottom = 16.dp)
                     .testTag("otf_access_token"),
@@ -141,7 +134,7 @@ fun AccessTokenRequestScreen(
             when (uiState) {
                 is UiState.Initial -> {}
                 is UiState.Error -> {
-                    errorSnackbarCallback(uiState.errorDescription)
+                    errorSnackBarCallback(uiState.errorDescription)
                 }
                 is UiState.Loading -> {
                     CircularProgressIndicator()
@@ -149,6 +142,7 @@ fun AccessTokenRequestScreen(
                 is UiState.Success -> {
                     Text(uiState.data.name)
                     Text(uiState.data.type)
+                    onOpenConfirmationDialog(true)
                 }
             }
         }
@@ -165,7 +159,8 @@ private fun LM_AccessTokenRequestScreenPreview() {
                 onAccessTokenChange = {},
                 onGetStartedButtonClick = {},
                 uiState = UiState.Initial,
-                errorSnackbarCallback = {},
+                errorSnackBarCallback = {},
+                onOpenConfirmationDialog = {},
             )
         }
     }
@@ -181,7 +176,8 @@ private fun DM_AccessTokenRequestScreenPreview() {
                 onAccessTokenChange = {},
                 onGetStartedButtonClick = {},
                 uiState = UiState.Initial,
-                errorSnackbarCallback = {},
+                errorSnackBarCallback = {},
+                onOpenConfirmationDialog = {},
             )
         }
     }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/screens/AccountAccessPage.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/screens/AccountAccessPage.kt
@@ -1,19 +1,24 @@
 package com.sycosoft.allsee.presentation.screens
 
 import android.annotation.SuppressLint
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import com.sycosoft.allsee.R
+import com.sycosoft.allsee.domain.models.NameAndAccountType
 import com.sycosoft.allsee.presentation.components.accountaccesspage.AccessTokenRequestScreen
+import com.sycosoft.allsee.presentation.utils.UiState
 import com.sycosoft.allsee.presentation.viewmodels.AccountAccessPageViewModel
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -21,10 +26,11 @@ import com.sycosoft.allsee.presentation.viewmodels.AccountAccessPageViewModel
 fun AccountAccessPage(
     viewModel: AccountAccessPageViewModel,
 ) {
-    var accessToken by remember { mutableStateOf("") }
+    val accessToken = viewModel.accessToken.collectAsState()
     val loadingState = viewModel.loadingState.collectAsState()
 
     val snackbarHostState = remember { SnackbarHostState() }
+    val openConfirmationDialog = remember { mutableStateOf(false) }
 
     Scaffold(
         snackbarHost = {
@@ -41,15 +47,41 @@ fun AccountAccessPage(
         }
     ) {
         AccessTokenRequestScreen(
-            accessToken = accessToken,
-            onAccessTokenChange = { accessToken = it },
-            onGetStartedButtonClick = { viewModel.saveToken(accessToken) },
+            accessToken = accessToken.value,
+            onAccessTokenChange = { viewModel.updateAccessToken(it) },
+            onGetStartedButtonClick = { viewModel.saveToken() },
             uiState = loadingState.value,
-            errorSnackbarCallback = { errorString ->
+            errorSnackBarCallback = { errorString ->
                 LaunchedEffect(snackbarHostState) {
                     snackbarHostState.showSnackbar(errorString)
                 }
-            }
+            },
+            onOpenConfirmationDialog = { openConfirmationDialog.value = it },
         )
+        when {
+            openConfirmationDialog.value -> {
+                // Given this dialog is open, it should be safe to say that we have successfully been given
+                // the Success UiState. We should be able to cast it to the correct object we need going forward.
+                val nameAndAccountType = loadingState.value as UiState.Success<NameAndAccountType>
+
+                AlertDialog(
+                    text = {
+                        Text(text = stringResource(id = R.string.adt_identity_confirmation, nameAndAccountType.data.name, nameAndAccountType.data.type))
+                    },
+                    onDismissRequest = {openConfirmationDialog.value = false },
+                    confirmButton = {
+                        // TODO: Navigate to main screen when confirmed (once implemented) for now, just dismiss.
+                        Button(onClick = { openConfirmationDialog.value = false }) {
+                            Text(text = "Yes")
+                        }
+                    },
+                    dismissButton = {
+                        Button(onClick = { openConfirmationDialog.value = false}) {
+                            Text("No")
+                        }
+                    }
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/theme/Theme.kt
@@ -16,8 +16,8 @@ private val DarkColorScheme = darkColorScheme(
     onSecondary = Color.White,
     //onTertiary = Color.White,
     onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    onSurfaceVariant = DarkBrown,
+    //onSurface = Color(0xFF1C1B1F),
+    //onSurfaceVariant = DarkBrown,
 )
 
 private val LightColorScheme = lightColorScheme(

--- a/app/src/main/java/com/sycosoft/allsee/presentation/theme/Type.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/theme/Type.kt
@@ -15,11 +15,15 @@ val Typography = Typography(
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
     ),
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
+        fontSize = 16.sp,
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Cursive,
+        fontWeight = FontWeight.Normal,
+        fontSize = 64.sp,
         lineHeight = 28.sp,
         letterSpacing = 0.sp
     ),
@@ -30,5 +34,4 @@ val Typography = Typography(
         lineHeight = 16.sp,
         letterSpacing = 0.5.sp
     )
-    */
 )

--- a/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountAccessPageViewModel.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountAccessPageViewModel.kt
@@ -20,13 +20,18 @@ class AccountAccessPageViewModel @Inject constructor(
     private var _loadingState = MutableStateFlow<UiState<NameAndAccountType>>(UiState.Initial)
     val loadingState: StateFlow<UiState<NameAndAccountType>> = _loadingState
 
-    fun saveToken(token: String) {
+    private var _accessToken = MutableStateFlow("")
+    val accessToken: StateFlow<String> = _accessToken
+
+    fun saveToken() {
         viewModelScope.launch {
             _loadingState.value = UiState.Loading
-            saveTokenUseCase(token)
+            saveTokenUseCase(_accessToken.value)
             getNameAndAccountType()
         }
     }
+
+    fun updateAccessToken(token: String) { _accessToken.value = token }
 
     private suspend fun getNameAndAccountType() = try {
         _loadingState.value = UiState.Success(getNameAndAccountTypeUseCase())

--- a/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountAccessPageViewModel.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountAccessPageViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.sycosoft.allsee.domain.exceptions.RepositoryException
 import com.sycosoft.allsee.domain.models.NameAndAccountType
 import com.sycosoft.allsee.domain.usecases.GetNameAndAccountTypeUseCase
+import com.sycosoft.allsee.domain.usecases.GetPersonUseCase
 import com.sycosoft.allsee.domain.usecases.SaveTokenUseCase
 import com.sycosoft.allsee.presentation.utils.UiState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ import javax.inject.Inject
 class AccountAccessPageViewModel @Inject constructor(
     private val saveTokenUseCase: SaveTokenUseCase,
     private val getNameAndAccountTypeUseCase: GetNameAndAccountTypeUseCase,
+    private val getPersonUseCase: GetPersonUseCase,
 ) : ViewModel() {
     private var _loadingState = MutableStateFlow<UiState<NameAndAccountType>>(UiState.Initial)
     val loadingState: StateFlow<UiState<NameAndAccountType>> = _loadingState
@@ -27,14 +29,14 @@ class AccountAccessPageViewModel @Inject constructor(
         viewModelScope.launch {
             _loadingState.value = UiState.Loading
             saveTokenUseCase(_accessToken.value)
-            getNameAndAccountType()
+            getPerson()
         }
     }
 
     fun updateAccessToken(token: String) { _accessToken.value = token }
 
-    private suspend fun getNameAndAccountType() = try {
-        _loadingState.value = UiState.Success(getNameAndAccountTypeUseCase())
+    private suspend fun getPerson() = try {
+        _loadingState.value = UiState.Success(getNameAndAccountTypeUseCase(getPersonUseCase()))
     } catch(e: RepositoryException) {
         _loadingState.value = UiState.Error(e.error.error, e.error.errorDescription)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="aap_get_started">To get started, paste your access token below.</string>
     <string name="aap_title">Oh, hey!</string>
 
+    <string name="adt_identity_confirmation">"Just to confirm, is your name %s and you hold a %s account?"</string>
+
     <string name = "button_get_started">Get Started</string>
 
     <string name = "error_internet_lost">Oh dear, it seems the internet is gone! Please reconnect to use this app.</string>


### PR DESCRIPTION
## Description

Changed the way name and account type details are retrieved. Instead of getting the account holder name and account holder details, this now retrieves account holder and individual identity. This means more information is pulled from the server, reducing the amount of calls. 

## What is the destination of this PR?

master

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code Changes

- Added getPerson() to AppRepository and AppRepositoryImpl
- Added getIdentity() to AppRepository and AppRepositoryImpl
- Added Identity
- Added IdentityDto
- Added Person
- Updated getNameAndAccountTypeUseCase
- Updated UseCaseModule to include GetPersonUseCase

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tests to follow on next commit

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
