### PR TITLE
Add person to database when user confirms identity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,6 +130,7 @@ dependencies {
 
     // Room Database
     implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
     testImplementation(libs.androidx.room.testing)
 }

--- a/app/src/androidTest/java/com/sycosoft/allsee/data/local/database/dao/PersonDaoTest.kt
+++ b/app/src/androidTest/java/com/sycosoft/allsee/data/local/database/dao/PersonDaoTest.kt
@@ -1,0 +1,97 @@
+package com.sycosoft.allsee.data.local.database.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.sycosoft.allsee.data.local.database.AppDatabase
+import com.sycosoft.allsee.data.local.models.PersonEntity
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PersonDaoTest {
+    private lateinit var database: AppDatabase
+    private lateinit var underTest: PersonDao
+
+    @Before
+    fun setup() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java,
+        ).allowMainThreadQueries().build()
+
+        underTest = database.personDao
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+    }
+
+    @Test
+    fun whenPersonObjectInserted_thenIdIsReturnedFromDatabase() = runTest {
+        val expected = 1L
+        val person = PersonEntity(
+            id = 0,
+            uid = "uid",
+            type = "INDIVIDUAL",
+            title = "Mr",
+            firstName = "Joe",
+            lastName = "Bloggs",
+            dob = "1975-01-01",
+            email = "test@test.com",
+            phone = "0123456789"
+        )
+
+        val actual = underTest.insertPerson(person)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun whenRequestingPersonWithValidId_thenPersonObjectIsReturned() = runTest {
+        val expected = PersonEntity(
+            id = 1,
+            uid = "uid",
+            type = "INDIVIDUAL",
+            title = "Mr",
+            firstName = "Joe",
+            lastName = "Bloggs",
+            dob = "1975-01-01",
+            email = "test@test.com",
+            phone = "0123456789"
+        )
+        underTest.insertPerson(expected)
+
+        val actual = underTest.getPersonById(expected.id)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun whenRequestingPersonWithInvalidId_thenNullIsReturned() = runTest {
+        val expected = null
+        val person = PersonEntity(
+            id = 1,
+            uid = "uid",
+            type = "INDIVIDUAL",
+            title = "Mr",
+            firstName = "Joe",
+            lastName = "Bloggs",
+            dob = "1975-01-01",
+            email = "test@test.com",
+            phone = "0123456789"
+        )
+
+        underTest.insertPerson(person)
+
+        val actual = underTest.getPersonById(2)
+
+        assertEquals(expected, actual)
+
+    }
+}

--- a/app/src/main/java/com/sycosoft/allsee/data/local/DatabaseException.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/local/DatabaseException.kt
@@ -1,0 +1,10 @@
+package com.sycosoft.allsee.data.local
+
+import com.sycosoft.allsee.domain.models.ErrorResponse
+import java.io.IOException
+
+/** Exception thrown when database call fails
+ *
+ * @see ErrorResponse for what is passed to the caller
+ * */
+class DatabaseException(val errorResponse: ErrorResponse) : IOException()

--- a/app/src/main/java/com/sycosoft/allsee/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/local/database/AppDatabase.kt
@@ -34,16 +34,18 @@ abstract class AppDatabase: RoomDatabase() {
                 // at any one time, preventing multiple threads from creating duplicate instances
                 // of the database.
                 synchronized(this) {
-                    INSTANCE = Room.databaseBuilder(
-                        context.applicationContext,
-                        AppDatabase::class.java,
-                        "allsee.db",
-                    )
-                        .fallbackToDestructiveMigration() // Set to allow destructive migration,
-                        // meaning if the database schema changes, it will drop the existing
-                        // database and recreate it.
-                        // TODO: Remove fallbackToDestructiveMigration for production release as we do not want this!
-                        .build()
+                   if(INSTANCE == null) {
+                         INSTANCE = Room.databaseBuilder(
+                            context.applicationContext,
+                            AppDatabase::class.java,
+                            "allsee.db",
+                        )
+                            .fallbackToDestructiveMigration() // Set to allow destructive migration,
+                            // meaning if the database schema changes, it will drop the existing
+                            // database and recreate it.
+                            // TODO: Remove fallbackToDestructiveMigration for production release as we do not want this!
+                            .build()
+                    }
                 }
             }
 
@@ -51,5 +53,6 @@ abstract class AppDatabase: RoomDatabase() {
             // singleton class), so return the instance.
             return INSTANCE!!
         }
+    }
     }
 }

--- a/app/src/main/java/com/sycosoft/allsee/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/local/database/AppDatabase.kt
@@ -1,0 +1,55 @@
+package com.sycosoft.allsee.data.local.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.sycosoft.allsee.data.local.database.dao.PersonDao
+import com.sycosoft.allsee.data.local.models.PersonEntity
+
+/**
+ * This manages our applications database connection.
+ *
+ * @author Jamie-Rhys Edwards
+ * @since v0.0.1
+ *
+ */
+// Let's define the databases configuration
+@Database(
+    entities = [PersonEntity::class,], // List of entity classes that will be a part of the database.
+    version = 3 // The version of the database.
+)
+abstract class AppDatabase: RoomDatabase() {
+    abstract val personDao: PersonDao
+
+    companion object {
+        // This volatile variable ensures that the value is read from and written to main memory directly,
+        // avoiding the use of a CPU cache, making it safe for multithreaded access.
+        @Volatile var INSTANCE: AppDatabase? = null
+
+        fun getDatabase(context: Context): AppDatabase {
+            // If the instance is null, the database has not yet been initialised.
+            if(INSTANCE == null) {
+                // Synchronised block ensures that only one thread can execute the code within it
+                // at any one time, preventing multiple threads from creating duplicate instances
+                // of the database.
+                synchronized(this) {
+                    INSTANCE = Room.databaseBuilder(
+                        context.applicationContext,
+                        AppDatabase::class.java,
+                        "allsee.db",
+                    )
+                        .fallbackToDestructiveMigration() // Set to allow destructive migration,
+                        // meaning if the database schema changes, it will drop the existing
+                        // database and recreate it.
+                        // TODO: Remove fallbackToDestructiveMigration for production release as we do not want this!
+                        .build()
+                }
+            }
+
+            // If the instance is not null, we've previously initialised the database (creating a
+            // singleton class), so return the instance.
+            return INSTANCE!!
+        }
+    }
+}

--- a/app/src/main/java/com/sycosoft/allsee/data/local/database/dao/PersonDao.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/local/database/dao/PersonDao.kt
@@ -1,0 +1,15 @@
+package com.sycosoft.allsee.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.sycosoft.allsee.data.local.models.PersonEntity
+
+@Dao
+interface PersonDao {
+    @Query("SELECT * FROM person WHERE id = :id")
+    suspend fun getPersonById(id: Int): PersonEntity?
+
+    @Insert
+    suspend fun insertPerson(person: PersonEntity): Long
+}

--- a/app/src/main/java/com/sycosoft/allsee/data/local/models/PersonEntity.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/local/models/PersonEntity.kt
@@ -1,0 +1,18 @@
+package com.sycosoft.allsee.data.local.models
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "person")
+data class PersonEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @ColumnInfo(name = "uid") val uid: String,
+    @ColumnInfo(name = "type")val type: String,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "first_name") val firstName: String,
+    @ColumnInfo(name = "last_name") val lastName: String,
+    @ColumnInfo(name = "dob") val dob: String,
+    @ColumnInfo(name = "email")val email: String,
+    @ColumnInfo(name = "phone") val phone: String,
+)

--- a/app/src/main/java/com/sycosoft/allsee/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/repository/AppRepositoryImpl.kt
@@ -1,31 +1,47 @@
 package com.sycosoft.allsee.data.repository
 
+import android.database.sqlite.SQLiteException
 import android.util.Log
+import com.sycosoft.allsee.data.local.DatabaseException
 import com.sycosoft.allsee.data.local.TokenProvider
+import com.sycosoft.allsee.data.local.database.dao.PersonDao
+import com.sycosoft.allsee.data.local.models.PersonEntity
 import com.sycosoft.allsee.domain.mappers.AccountHolderMapper
 import com.sycosoft.allsee.domain.mappers.ErrorResponseMapper
 import com.sycosoft.allsee.domain.mappers.IdentityMapper
 import com.sycosoft.allsee.data.remote.exceptions.ApiException
 import com.sycosoft.allsee.data.remote.services.StarlingBankApiService
 import com.sycosoft.allsee.domain.exceptions.RepositoryException
+import com.sycosoft.allsee.domain.mappers.PersonMapper
 import com.sycosoft.allsee.domain.models.AccountHolder
 import com.sycosoft.allsee.domain.models.ErrorResponse
 import com.sycosoft.allsee.domain.models.Identity
 import com.sycosoft.allsee.domain.models.Person
 import com.sycosoft.allsee.domain.repository.AppRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class AppRepositoryImpl @Inject constructor(
     private val apiService: StarlingBankApiService,
+    private val personDao: PersonDao,
     private val tokenProvider: TokenProvider,
     private val identityMapper: IdentityMapper,
+    private val personMapper: PersonMapper,
 ) : AppRepository {
     private val logTag = AppRepositoryImpl::class.java.simpleName
 
     override suspend fun saveToken(token: String) {
         tokenProvider.saveToken(token)
+    }
+
+    override suspend fun savePerson(person: Person): Long = try {
+        databaseCall { personDao.insertPerson(personMapper.toEntity(person)) }
+    } catch(e: DatabaseException) {
+        throw RepositoryException(e.errorResponse)
     }
 
     @Throws(RepositoryException::class)
@@ -45,21 +61,31 @@ class AppRepositoryImpl @Inject constructor(
     @Throws(RepositoryException::class)
     override suspend fun getPerson(): Person = try {
         coroutineScope {
-            val accountHolder = async { getAccountHolder() }.await()
-            val identity = async { getIdentity() }.await()
+            var person = personDao.getPersonById(1)
 
-            Person(
-                uid = accountHolder.uid,
-                type = accountHolder.type,
-                title = identity.title,
-                firstName = identity.firstName,
-                lastName = identity.lastName,
-                dob = identity.dob,
-                email = identity.email,
-                phone = identity.phone,
-            )
+            if (person == null) {
+                val accountHolder = async { getAccountHolder() }.await()
+                val identity = async { getIdentity() }.await()
+
+                person = PersonEntity(
+                    uid = accountHolder.uid,
+                    type = accountHolder.type.toString(),
+                    title = identity.title,
+                    firstName = identity.firstName,
+                    lastName = identity.lastName,
+                    dob = identity.dob.toString(),
+                    email = identity.email,
+                    phone = identity.phone,
+                )
+
+                savePerson(personMapper.toDomain(person))
+            }
+
+            personMapper.toDomain(person)
         }
     } catch(e: ApiException) {
+        throw throwRepositoryException(e)
+    } catch(e: DatabaseException) {
         throw throwRepositoryException(e)
     }
 
@@ -75,6 +101,36 @@ class AppRepositoryImpl @Inject constructor(
             )
         } else {
             RepositoryException(error = ErrorResponseMapper.toDomain(e.errorResponse))
+        }
+    }
+
+    private fun throwRepositoryException(e: DatabaseException): RepositoryException {
+        Log.e(logTag, "error = ${e.errorResponse.error}, errorDescription = ${e.errorResponse.errorDescription}")
+
+        return RepositoryException(error = e.errorResponse)
+    }
+
+    @Throws(DatabaseException::class)
+    private suspend fun <T> databaseCall(operation: suspend () -> T): T {
+        return withContext(Dispatchers.IO) {
+            try {
+                operation()
+            } catch(e: SQLiteException) {
+                coroutineContext.ensureActive()
+                Log.e(logTag, "Database Error: {SQLiteException}: ${e.message}")
+
+                throw DatabaseException(ErrorResponse("database_error", "{SQLiteException}: ${e.message}"))
+            } catch(e: IllegalStateException) {
+                coroutineContext.ensureActive()
+                Log.e(logTag, "Database Error: {IllegalStateException}: ${e.message}")
+
+                throw DatabaseException(ErrorResponse("database_error", e.message.toString()))
+            } catch(e: Exception) {
+                coroutineContext.ensureActive()
+                Log.e(logTag, "Database Error: {Unknown}: ${e.message}")
+
+                throw DatabaseException(ErrorResponse("database_error", "Unknown Database Error: ${e.message.toString()}"))
+            }
         }
     }
 }

--- a/app/src/main/java/com/sycosoft/allsee/di/modules/LocalModule.kt
+++ b/app/src/main/java/com/sycosoft/allsee/di/modules/LocalModule.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import com.sycosoft.allsee.data.local.TokenProvider
+import com.sycosoft.allsee.data.local.database.AppDatabase
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -34,4 +35,12 @@ class LocalModule {
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
         )
+
+    @Provides
+    @Singleton
+    fun provideAppDatabase(context: Context): AppDatabase = AppDatabase.getDatabase(context)
+
+    @Provides
+    @Singleton
+    fun providePersonDao(appDatabase: AppDatabase) = appDatabase.personDao
 }

--- a/app/src/main/java/com/sycosoft/allsee/di/modules/RepositoryModule.kt
+++ b/app/src/main/java/com/sycosoft/allsee/di/modules/RepositoryModule.kt
@@ -1,9 +1,11 @@
 package com.sycosoft.allsee.di.modules
 
 import com.sycosoft.allsee.data.local.TokenProvider
+import com.sycosoft.allsee.data.local.database.dao.PersonDao
 import com.sycosoft.allsee.domain.mappers.IdentityMapper
 import com.sycosoft.allsee.data.remote.services.StarlingBankApiService
 import com.sycosoft.allsee.data.repository.AppRepositoryImpl
+import com.sycosoft.allsee.domain.mappers.PersonMapper
 import com.sycosoft.allsee.domain.repository.AppRepository
 import dagger.Module
 import dagger.Provides
@@ -15,11 +17,15 @@ class RepositoryModule {
     @Singleton
     fun provideAppRepository(
         apiService: StarlingBankApiService,
+        personDao: PersonDao,
         tokenProvider: TokenProvider,
         identityMapper: IdentityMapper,
+        personMapper: PersonMapper,
     ): AppRepository = AppRepositoryImpl(
         apiService = apiService,
+        personDao = personDao,
         tokenProvider = tokenProvider,
         identityMapper = identityMapper,
+        personMapper = personMapper,
     )
 }

--- a/app/src/main/java/com/sycosoft/allsee/domain/mappers/PersonMapper.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/mappers/PersonMapper.kt
@@ -18,4 +18,16 @@ class PersonMapper @Inject constructor() {
         email = entity.email,
         phone = entity.phone,
     )
+
+    fun toEntity(domain: Person): PersonEntity = PersonEntity(
+        id = domain.id,
+        uid = domain.uid,
+        type = domain.type.name,
+        title = domain.title,
+        firstName = domain.firstName,
+        lastName = domain.lastName,
+        dob = domain.dob.toString(),
+        email = domain.email,
+        phone = domain.phone,
+    )
 }

--- a/app/src/main/java/com/sycosoft/allsee/domain/models/Person.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/models/Person.kt
@@ -4,6 +4,7 @@ import com.sycosoft.allsee.domain.models.types.AccountHolderType
 import java.time.LocalDate
 
 data class Person(
+    val id: Int = 0,
     val uid: String,
     val type: AccountHolderType,
     val title: String,

--- a/app/src/main/java/com/sycosoft/allsee/domain/repository/AppRepository.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/repository/AppRepository.kt
@@ -10,6 +10,9 @@ interface AppRepository {
     /** Encrypts the given token and then saves the result into the [TokenProvider] */
     suspend fun saveToken(token: String)
 
+    /** Saves Person to the database so that it can be retrieved later */
+    suspend fun savePerson(person: Person): Long
+
     /** Retrieves the account holder */
     @Throws(RepositoryException::class)
     suspend fun getAccountHolder(): AccountHolder

--- a/app/src/test/java/com/sycosoft/allsee/data/repository/AppRepositoryImplTest.kt
+++ b/app/src/test/java/com/sycosoft/allsee/data/repository/AppRepositoryImplTest.kt
@@ -1,7 +1,10 @@
 package com.sycosoft.allsee.data.repository
 
 import android.util.Log
+import com.sycosoft.allsee.data.local.DatabaseException
 import com.sycosoft.allsee.data.local.TokenProvider
+import com.sycosoft.allsee.data.local.database.dao.PersonDao
+import com.sycosoft.allsee.data.local.models.PersonEntity
 import com.sycosoft.allsee.domain.mappers.AccountHolderMapper
 import com.sycosoft.allsee.domain.mappers.ErrorResponseMapper
 import com.sycosoft.allsee.domain.mappers.IdentityMapper
@@ -11,6 +14,8 @@ import com.sycosoft.allsee.data.remote.models.ErrorResponseDto
 import com.sycosoft.allsee.data.remote.models.IdentityDto
 import com.sycosoft.allsee.data.remote.services.StarlingBankApiService
 import com.sycosoft.allsee.domain.exceptions.RepositoryException
+import com.sycosoft.allsee.domain.mappers.PersonMapper
+import com.sycosoft.allsee.domain.models.ErrorResponse
 import com.sycosoft.allsee.domain.models.Person
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -26,7 +31,9 @@ import org.junit.Test
 class AppRepositoryImplTest {
     private val apiService: StarlingBankApiService = mockk(relaxed = true)
     private val tokenProvider: TokenProvider = mockk(relaxed = true)
+    private val personDao: PersonDao = mockk(relaxed = true)
     private val identityMapper: IdentityMapper = IdentityMapper()
+    private val personMapper: PersonMapper = PersonMapper()
     private lateinit var underTest: AppRepositoryImpl
 
     private val errorResponseDto = ErrorResponseDto("error", "Error Description")
@@ -34,7 +41,13 @@ class AppRepositoryImplTest {
 
     @Before
     fun setUp() {
-        underTest = AppRepositoryImpl(apiService, tokenProvider, identityMapper)
+        underTest = AppRepositoryImpl(
+            apiService = apiService,
+            personDao = personDao,
+            tokenProvider = tokenProvider,
+            identityMapper = identityMapper,
+            personMapper = personMapper,
+        )
 
         mockkStatic(Log::class)
         every { Log.e(any(), any()) } returns 0
@@ -108,12 +121,53 @@ class AppRepositoryImplTest {
 
     // Get Person
     @Test
+    fun `When Database returns valid object, Then database person is returned`() = runBlocking {
+        val accountHolderDto = AccountHolderDto("012456789", "INDIVIDUAL")
+        val identityDto = IdentityDto("Mr", "John", "Doe", "1975-01-01", "joe.bloggs@example.com", "0123456789")
+        val expected = personMapper.toDomain(
+            PersonEntity(
+                id = 0,
+                uid = accountHolderDto.accountHolderUid,
+                type = AccountHolderMapper.toDomain(accountHolderDto).type.toString(),
+                title = identityDto.title,
+                firstName = identityDto.firstName,
+                lastName = identityDto.lastName,
+                dob = identityDto.dateOfBirth,
+                email = identityDto.email,
+                phone = identityDto.phone
+            )
+        )
+
+        coEvery { personDao.getPersonById(any()) } returns null
+        coEvery { apiService.getAccountHolder() } returns accountHolderDto
+        coEvery { apiService.getIdentity() } returns identityDto
+
+        val actual = underTest.getPerson()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `When DatabaseException thrown during saving of person, Then RepositoryException should be returned and no person object returned`() = runBlocking {
+        val expected = DatabaseException(ErrorResponse("error", "Error Response"))
+        coEvery { personDao.getPersonById(any()) } throws expected
+
+        try {
+            underTest.getPerson()
+            fail("Expected RepositoryException to be thrown")
+        } catch(e: RepositoryException) {
+            assertEquals(expected.errorResponse, e.error)
+        }
+    }
+
+    @Test
     fun `When API succeeds, Then person object is returned`() = runBlocking {
         val accountHolderDto = AccountHolderDto("012456789", "INDIVIDUAL")
         val identityDto = IdentityDto("Mr", "John", "Doe", "1975-01-01", "joe.bloggs@example.com", "0123456789")
         val identity = identityMapper.toDomain(identityDto)
         val accountHolder = AccountHolderMapper.toDomain(accountHolderDto)
 
+        coEvery { personDao.getPersonById(any()) } returns null
         coEvery { apiService.getAccountHolder() } returns accountHolderDto
         coEvery { apiService.getIdentity() } returns identityDto
 
@@ -133,6 +187,7 @@ class AppRepositoryImplTest {
 
     @Test
     fun `When ApiException thrown in getAccountHolder from getPerson, Then RepositoryException should be thrown and no object returned`() = runBlocking {
+        coEvery { personDao.getPersonById(any()) } returns null
         coEvery { apiService.getAccountHolder() } throws ApiException(errorResponseDto)
 
         try {
@@ -145,6 +200,7 @@ class AppRepositoryImplTest {
 
     @Test
     fun `When ApiException thrown in getIdentity from getPerson, Then RepositoryException should be thrown and no object returned`() = runBlocking {
+        coEvery { personDao.getPersonById(any()) } returns null
         coEvery { apiService.getAccountHolder() } returns AccountHolderDto("0123456789", "INDIVIDUAL")
         coEvery { apiService.getAccountHolder() } throws ApiException(errorResponseDto)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ androidx-constraintlayout-compose = { module = "androidx.constraintlayout:constr
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomRuntime" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "roomRuntime" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }


### PR DESCRIPTION
## Description

When the user confirms their identity in the AccessTokenRequestScreen, getPerson in AppRepositoryImpl now checks the database to see if there is already an entry for the user. If there is not, null will be passed in. getPerson will then request relevant details from the API and then, all going well, will save a Person entity object into the database and return it.

## What is the destination of this PR?

master

Closes #55 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code Changes

- Updated getPerson in AppRepositoryImpl to check if person is present in database and then queries api if null.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- PersonDao is tested
- RepositoryImpl is tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
