### PR TITLE
Displays account type in app bar on HomePageScreen

### DIFF
--- a/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/accountaccesspage/AccessTokenRequestScreenTest.kt
+++ b/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/accountaccesspage/AccessTokenRequestScreenTest.kt
@@ -13,7 +13,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
-class AccessTokenRequestScreenKtTest {
+class AccessTokenRequestScreenTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test

--- a/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/homepage/HomePageScreenTest.kt
+++ b/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/homepage/HomePageScreenTest.kt
@@ -1,0 +1,107 @@
+package com.sycosoft.allsee.presentation.components.homepage
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.Surface
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.sycosoft.allsee.presentation.theme.AllSeeTheme
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class HomePageScreenTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun whenScreenInDefaultState_thenEnsureCorrectComponentsAreDisplayed() {
+        // When
+        composeTestRule.setContent {
+            AllSeeTheme {
+                Surface {
+                    HomePageScreen(
+                        accountName = "Individual",
+                        onPersonButtonClick = { /*TODO*/ },
+                        innerPadding = PaddingValues()
+                    )
+                }
+            }
+        }
+
+        // Then and Verify
+        composeTestRule.onNodeWithTag("hps_account_name").isDisplayed()
+        composeTestRule.onNodeWithTag("hps_person_button").isDisplayed()
+    }
+
+    // #############################################################################################
+    // ## Account Name Label                                                                      ##
+    // #############################################################################################
+
+    @Test
+    fun whenScreenInitiallyShown_thenAccountNameLabelShouldDisplayLoadingText() {
+        // When
+        val expected = "Loading"
+        composeTestRule.setContent {
+            AllSeeTheme {
+                Surface {
+                    HomePageScreen(
+                        accountName = null,
+                        onPersonButtonClick = {},
+                        innerPadding = PaddingValues()
+                    )
+                }
+            }
+        }
+
+        // Then and Verify
+        composeTestRule.onNodeWithTag("hps_account_name").assertTextEquals(expected)
+    }
+
+    @Test
+    fun whenScreenLoadedWithAccountName_thenAccountNameLabelShouldDisplayValue() {
+        // When
+        val expected = "Individual"
+        composeTestRule.setContent {
+            AllSeeTheme {
+                Surface {
+                    HomePageScreen(
+                        accountName = expected,
+                        onPersonButtonClick = {},
+                        innerPadding = PaddingValues()
+                    )
+                }
+            }
+        }
+
+        // Then and Verify
+        composeTestRule.onNodeWithTag("hps_account_name").assertTextEquals(expected)
+    }
+
+    // #############################################################################################
+    // ## Person Button                                                                           ##
+    // #############################################################################################
+
+    @Test
+    fun whenPersonButtonPressed_thenPersonButtonClickShouldFire() {
+        // When
+        var buttonClicked = false
+
+        composeTestRule.setContent {
+            AllSeeTheme {
+                Surface {
+                    HomePageScreen(
+                        accountName = null,
+                        onPersonButtonClick = { buttonClicked = true },
+                        innerPadding = PaddingValues()
+                    )
+                }
+            }
+        }
+
+        // Then and Verify
+        composeTestRule.onNodeWithTag("hps_person_button").performClick()
+        assertTrue(buttonClicked)
+    }
+}

--- a/app/src/main/java/com/sycosoft/allsee/presentation/components/homepage/HomePageScreen.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/components/homepage/HomePageScreen.kt
@@ -1,5 +1,6 @@
 package com.sycosoft.allsee.presentation.components.homepage
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -9,8 +10,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -20,118 +29,150 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.sycosoft.allsee.presentation.theme.AllSeeTheme
 
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun HomePageScreen(
     topSectionColor: Color = MaterialTheme.colorScheme.surface,
     bottomSectionColor: Color = MaterialTheme.colorScheme.inverseSurface,
+    accountName: String?,
+    onPersonButtonClick: () -> Unit,
     innerPadding: PaddingValues,
 ) {
     val topSectionHeight = 0.90f
     val bottomSectionHeight = 0.10f
     val roundedCornerSize = 30.dp
-    ConstraintLayout(
-        modifier = Modifier
-            .fillMaxSize()
-            .testTag("screen_home_page")
-    ) {
-        val (
-            backgroundTop,
-            backgroundTopRight,
-            backgroundBottomLeft,
-            backgroundBottom,
-            foregroundTop,
-            foregroundBottom,
-        ) = createRefs()
 
-        // Background/TopRight
-        Box(
-            modifier = Modifier
-                .fillMaxWidth(0.25f)
-                .fillMaxHeight(topSectionHeight)
-                .background(color = bottomSectionColor)
-                .constrainAs(backgroundTopRight) {
-                    top.linkTo(parent.top)
-                    bottom.linkTo(backgroundBottom.top)
-                    end.linkTo(parent.end)
+    Scaffold(
+        modifier = Modifier.testTag("screen_home_page"),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        modifier = Modifier
+                            .testTag("hps_account_name")
+                            .padding(start = 5.dp),
+                        text = accountName ?: "Loading",
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                },
+                actions = {
+                    IconButton(
+                        modifier = Modifier.testTag("hps_person_button"),
+                        onClick = onPersonButtonClick
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Person,
+                            contentDescription = null
+                        )
+                    }
                 }
-        )
-
-        // Background/Top
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(topSectionHeight)
-                .background(
-                    color = topSectionColor,
-                    shape = RoundedCornerShape(bottomEnd = roundedCornerSize)
-                )
-                .constrainAs(backgroundTop) {
-                    top.linkTo(parent.top)
-                    bottom.linkTo(backgroundBottom.top)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
-        )
-        
-        // Background/BottomLeft
-        Box(
-            modifier = Modifier
-                .fillMaxWidth(0.25f)
-                .fillMaxHeight(bottomSectionHeight)
-                .background(color = topSectionColor)
-                .constrainAs(backgroundBottomLeft) {
-                    top.linkTo(backgroundTop.bottom)
-                    bottom.linkTo(parent.bottom)
-                    start.linkTo(parent.start)
-                }
-        )
-
-        // Background/Bottom
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(bottomSectionHeight)
-                .background(
-                    color = bottomSectionColor,
-                    shape = RoundedCornerShape(topStart = roundedCornerSize)
-                )
-                .constrainAs(backgroundBottom) {
-                    top.linkTo(backgroundTop.bottom)
-                    bottom.linkTo(parent.bottom)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
-        )
-
-        // Foreground/Top
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(topSectionHeight)
-                .padding(top = innerPadding.calculateTopPadding())
-                .constrainAs(foregroundTop) {
-                    top.linkTo(backgroundTop.top)
-                    bottom.linkTo(backgroundTop.bottom)
-                    start.linkTo(backgroundTop.start)
-                    end.linkTo(backgroundTop.end)
-                }
-        ) {
-
+            )
         }
-
-        // Foreground/Bottom
-        Box(
+    ) {
+        ConstraintLayout(
             modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(bottomSectionHeight)
-                .constrainAs(foregroundBottom) {
-                    top.linkTo(backgroundBottom.top)
-                    bottom.linkTo(backgroundBottom.bottom)
-                    start.linkTo(backgroundBottom.start)
-                    end.linkTo(backgroundBottom.end)
-                }
+                .fillMaxSize()
         ) {
+            val (
+                backgroundTop,
+                backgroundTopRight,
+                backgroundBottomLeft,
+                backgroundBottom,
+                foregroundTop,
+                foregroundBottom,
+            ) = createRefs()
 
+            // Background/TopRight
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.25f)
+                    .fillMaxHeight(topSectionHeight)
+                    .background(color = bottomSectionColor)
+                    .constrainAs(backgroundTopRight) {
+                        top.linkTo(parent.top)
+                        bottom.linkTo(backgroundBottom.top)
+                        end.linkTo(parent.end)
+                    }
+            )
+
+            // Background/Top
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(topSectionHeight)
+                    .background(
+                        color = topSectionColor,
+                        shape = RoundedCornerShape(bottomEnd = roundedCornerSize)
+                    )
+                    .constrainAs(backgroundTop) {
+                        top.linkTo(parent.top)
+                        bottom.linkTo(backgroundBottom.top)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                    }
+            )
+
+            // Background/BottomLeft
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.25f)
+                    .fillMaxHeight(bottomSectionHeight)
+                    .background(color = topSectionColor)
+                    .constrainAs(backgroundBottomLeft) {
+                        top.linkTo(backgroundTop.bottom)
+                        bottom.linkTo(parent.bottom)
+                        start.linkTo(parent.start)
+                    }
+            )
+
+            // Background/Bottom
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(bottomSectionHeight)
+                    .background(
+                        color = bottomSectionColor,
+                        shape = RoundedCornerShape(topStart = roundedCornerSize)
+                    )
+                    .constrainAs(backgroundBottom) {
+                        top.linkTo(backgroundTop.bottom)
+                        bottom.linkTo(parent.bottom)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                    }
+            )
+
+            // Foreground/Top
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(topSectionHeight)
+                    .padding(top = innerPadding.calculateTopPadding())
+                    .constrainAs(foregroundTop) {
+                        top.linkTo(backgroundTop.top)
+                        bottom.linkTo(backgroundTop.bottom)
+                        start.linkTo(backgroundTop.start)
+                        end.linkTo(backgroundTop.end)
+                    }
+            ) {
+
+            }
+
+            // Foreground/Bottom
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(bottomSectionHeight)
+                    .constrainAs(foregroundBottom) {
+                        top.linkTo(backgroundBottom.top)
+                        bottom.linkTo(backgroundBottom.bottom)
+                        start.linkTo(backgroundBottom.start)
+                        end.linkTo(backgroundBottom.end)
+                    }
+            ) {
+
+            }
         }
     }
 }
@@ -142,7 +183,9 @@ private fun LM_HomePageScreenPreview() {
     AllSeeTheme(dynamicColor = false) {
         Surface {
             HomePageScreen(
-                innerPadding = PaddingValues()
+                innerPadding = PaddingValues(),
+                accountName = "Individual",
+                onPersonButtonClick = {},
             )
         }
     }
@@ -156,7 +199,9 @@ private fun DM_HomePageScreenPreview() {
     AllSeeTheme(dynamicColor = false) {
         Surface {
             HomePageScreen(
-                innerPadding = PaddingValues()
+                innerPadding = PaddingValues(),
+                accountName = "Individual",
+                onPersonButtonClick = {},
             )
         }
     }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/pages/HomePage.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/pages/HomePage.kt
@@ -2,14 +2,19 @@ package com.sycosoft.allsee.presentation.pages
 
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import com.sycosoft.allsee.presentation.components.homepage.HomePageScreen
 import com.sycosoft.allsee.presentation.viewmodels.HomePageViewModel
 
 @Composable
 fun HomePage(viewModel: HomePageViewModel) {
+    val personDetails = viewModel.personDetails.collectAsState()
+
     Scaffold { innerPadding ->
         HomePageScreen(
             innerPadding = innerPadding,
+            accountName = personDetails.value?.type?.displayName,
+            onPersonButtonClick = {},
         )
     }
 }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/HomePageViewModel.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/HomePageViewModel.kt
@@ -1,7 +1,23 @@
 package com.sycosoft.allsee.presentation.viewmodels
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sycosoft.allsee.domain.models.Person
+import com.sycosoft.allsee.domain.usecases.GetPersonUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-class HomePageViewModel @Inject constructor() : ViewModel() {
+class HomePageViewModel @Inject constructor(
+    private val getPersonUseCase: GetPersonUseCase,
+) : ViewModel() {
+    private val _personDetails = MutableStateFlow<Person?>(null)
+    val personDetails: StateFlow<Person?> = _personDetails
+
+    init {
+        viewModelScope.launch {
+            _personDetails.value = getPersonUseCase()
+        }
+    }
 }


### PR DESCRIPTION
## Description

This PR adds functionality to allow the account type to be displayed on the top app bar in the home page screen. This also includes tests for the screen.

## What is the destination of this PR?

master

Closes #56 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code Changes

- Updated ViewModel to include an init to populate the person details variable used by HomePageScreen.
- Updated HomePage to pass in variables needed for HomePageScreen

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Integration Test:
    - Ensure correct components are displayed when screen is in a default state.
    - Ensure account type label displays loading when person details are null.
    - Ensure account type label displays properly when provided type.
    - Ensure that person button triggers on click correctly when pressed.
- Manual Testing:
    - Pasted in correct access token to get valid details. Ensured that the correct account type is displayed in label.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
