### PR TITLE
feature/add-user-confirmation-dialog-class

### DIFF
--- a/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/accountaccesspage/AccessTokenRequestScreenTest.kt
+++ b/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/accountaccesspage/AccessTokenRequestScreenTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import com.sycosoft.allsee.presentation.components.screens.accountaccesspage.AccessTokenRequestScreen
+import com.sycosoft.allsee.presentation.components.screens.accountaccesspage.AccessTokenRequestScreenTestTags
 import com.sycosoft.allsee.presentation.theme.AllSeeTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule

--- a/app/src/main/java/com/sycosoft/allsee/presentation/components/dialogs/UserConfirmationDialog.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/components/dialogs/UserConfirmationDialog.kt
@@ -1,0 +1,53 @@
+package com.sycosoft.allsee.presentation.components.dialogs
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.sycosoft.allsee.R
+
+@Composable
+fun UserConfirmationDialog(
+    modifier: Modifier = Modifier,
+    name: String,
+    accountType: String,
+    onDismissButtonClick: () -> Unit,
+    onConfirmButtonClick: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    AlertDialog(
+        modifier = modifier,
+        onDismissRequest = onDismissRequest,
+        title = {
+            Text(
+                modifier = Modifier.testTag(UserConfirmationDialogTestTags.TITLE),
+                text = stringResource(R.string.user_confirmation_dialog_title)
+            )
+        },
+        text = {
+            Text(
+                modifier = Modifier.testTag(UserConfirmationDialogTestTags.TEXT),
+                text = stringResource(R.string.user_confirmation_dialog_text, name, accountType)
+            )
+        },
+        confirmButton = {
+            Button(
+                modifier = Modifier.testTag(UserConfirmationDialogTestTags.CONFIRM_BUTTON),
+                onClick = onConfirmButtonClick,
+            ) {
+                Text(text = stringResource(R.string.button_yes))
+            }
+        },
+        dismissButton = {
+            Button(
+                modifier = Modifier.testTag(UserConfirmationDialogTestTags.DISMISS_BUTTON),
+                onClick = onDismissButtonClick,
+            ) {
+                Text(text = stringResource(R.string.button_no))
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/sycosoft/allsee/presentation/components/dialogs/UserConfirmationDialogTestTags.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/components/dialogs/UserConfirmationDialogTestTags.kt
@@ -1,0 +1,8 @@
+package com.sycosoft.allsee.presentation.components.dialogs
+
+object UserConfirmationDialogTestTags {
+    const val TITLE = "user_confirmation_dialog_title"
+    const val TEXT = "user_confirmation_dialog_text"
+    const val CONFIRM_BUTTON = "user_confirmation_dialog_confirm_button"
+    const val DISMISS_BUTTON = "user_confirmation_dialog_dismiss_button"
+}

--- a/app/src/main/java/com/sycosoft/allsee/presentation/pages/AccountAccessPage.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/pages/AccountAccessPage.kt
@@ -1,23 +1,19 @@
 package com.sycosoft.allsee.presentation.pages
 
 import android.annotation.SuppressLint
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.res.stringResource
-import com.sycosoft.allsee.R
 import com.sycosoft.allsee.domain.models.NameAndAccountType
-import com.sycosoft.allsee.presentation.components.accountaccesspage.AccessTokenRequestScreen
+import com.sycosoft.allsee.presentation.components.dialogs.UserConfirmationDialog
+import com.sycosoft.allsee.presentation.components.screens.accountaccesspage.AccessTokenRequestScreen
 import com.sycosoft.allsee.presentation.utils.UiState
 import com.sycosoft.allsee.presentation.viewmodels.AccountAccessPageViewModel
 
@@ -78,29 +74,19 @@ fun AccountAccessPage(
                 // the Success UiState. We should be able to cast it to the correct object we need going forward.
                 val nameAndAccountType = loadingState.value as UiState.Success<NameAndAccountType>
 
-                AlertDialog(
-                    text = {
-                        Text(text = stringResource(id = R.string.adt_identity_confirmation, nameAndAccountType.data.name, nameAndAccountType.data.type))
+                UserConfirmationDialog(
+                    name = nameAndAccountType.data.name,
+                    accountType = nameAndAccountType.data.type,
+                    onDismissButtonClick = {
+                        openConfirmationDialog.value = false
+                        viewModel.resetLoadingState()
+                    },
+                    onConfirmButtonClick = {
+                        onNavigateToHomePage()
                     },
                     onDismissRequest = {
                         openConfirmationDialog.value = false
                         viewModel.resetLoadingState()
-                    },
-                    confirmButton = {
-                        // TODO: Navigate to main screen when confirmed (once implemented) for now, just dismiss.
-                        Button(onClick = {
-                            onNavigateToHomePage()
-                        }) {
-                            Text(text = "Yes")
-                        }
-                    },
-                    dismissButton = {
-                        Button(onClick = {
-                            openConfirmationDialog.value = false
-                            viewModel.resetLoadingState()
-                        }) {
-                            Text("No")
-                        }
                     }
                 )
             }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/pages/HomePage.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/pages/HomePage.kt
@@ -3,7 +3,7 @@ package com.sycosoft.allsee.presentation.pages
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import com.sycosoft.allsee.presentation.components.homepage.HomePageScreen
+import com.sycosoft.allsee.presentation.components.screens.homepage.HomePageScreen
 import com.sycosoft.allsee.presentation.viewmodels.HomePageViewModel
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,9 +5,12 @@
     <string name="aap_get_started">To get started, paste your access token below.</string>
     <string name="aap_title">Oh, hey!</string>
 
-    <string name="adt_identity_confirmation">"Just to confirm, is your name %s and you hold a %s account?"</string>
+    <string name="user_confirmation_dialog_title">Hold on a second!</string>
+    <string name="user_confirmation_dialog_text">Just to confirm, is your name %s and you hold a %s account?</string>
 
     <string name = "button_get_started">Get Started</string>
+    <string name="button_no">No</string>
+    <string name="button_yes">Yes</string>
 
     <string name = "error_internet_lost">Oh dear, it seems the internet is gone! Please reconnect to use this app.</string>
 </resources>


### PR DESCRIPTION
## Description

This PR implements a confirmation dialog which asks the user to confirm they are the account holder. This is to further separate and clean up the AccessTokenRequestScreen. 

## What is the destination of this PR?

Closes #65

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code Changes

- Add User Confirmation Dialog class
- Add User Confirmation Dialog test tags

# How Has This Been Tested?

Tests to follow in next commit

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
