### PR TITLE
Feature/account access move to viewstate

### DIFF
--- a/app/src/main/java/com/sycosoft/allsee/presentation/pages/AccountAccessPage.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/pages/AccountAccessPage.kt
@@ -53,9 +53,9 @@ fun AccountAccessPage(
                 UserConfirmationDialog(
                     name = state.data.name,
                     accountType = state.data.type,
-                    onDismissButtonClick = { viewModel.resetLoadingState() },
-                    onConfirmButtonClick = { onNavigateToHomePage() },
-                    onDismissRequest = { viewModel.resetLoadingState() }
+                    onDismissButtonClick = remember { viewModel::resetLoadingState },
+                    onConfirmButtonClick = remember { { onNavigateToHomePage() } },
+                    onDismissRequest = remember { viewModel::resetLoadingState }
                 )
 
             is UiState.Error ->

--- a/app/src/main/java/com/sycosoft/allsee/presentation/pages/AccountAccessPage.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/pages/AccountAccessPage.kt
@@ -8,9 +8,9 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sycosoft.allsee.domain.models.NameAndAccountType
 import com.sycosoft.allsee.presentation.components.dialogs.UserConfirmationDialog
 import com.sycosoft.allsee.presentation.components.screens.accountaccesspage.AccessTokenRequestScreen
@@ -23,12 +23,8 @@ fun AccountAccessPage(
     viewModel: AccountAccessPageViewModel,
     onNavigateToHomePage: () -> Unit,
 ) {
-    val accessToken = viewModel.accessToken.collectAsState()
-    val loadingState = viewModel.loadingState.collectAsState()
-
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val showProgressBar = remember { mutableStateOf(false) }
-    val openConfirmationDialog = remember { mutableStateOf(false) }
 
     Scaffold(
         snackbarHost = {
@@ -45,51 +41,29 @@ fun AccountAccessPage(
         }
     ) {
         AccessTokenRequestScreen(
-            accessToken = accessToken.value,
-            onAccessTokenChange = { viewModel.updateAccessToken(it) },
-            showProgressBar = showProgressBar.value,
-            onButtonClick = { viewModel.saveToken() },
+            accessToken = viewState.accessToken,
+            onAccessTokenChange = remember { viewModel::updateAccessToken },
+            showProgressBar = viewState.nameAndAccountState is UiState.Loading,
+            onButtonClick = remember { viewModel::saveToken },
         )
-        when (val state = loadingState.value) {
-            is UiState.Initial -> {
-                showProgressBar.value = false
-            }
-            is UiState.Loading -> {
-                showProgressBar.value = true
-            }
-            is UiState.Success -> {
-                showProgressBar.value = false
-                openConfirmationDialog.value = true
-            }
-            is UiState.Error -> {
-                showProgressBar.value = false
-                LaunchedEffect(snackbarHostState) {
+
+        when (val state = viewState.nameAndAccountState) {
+
+            is UiState.Success<NameAndAccountType> ->
+                UserConfirmationDialog(
+                    name = state.data.name,
+                    accountType = state.data.type,
+                    onDismissButtonClick = { viewModel.resetLoadingState() },
+                    onConfirmButtonClick = { onNavigateToHomePage() },
+                    onDismissRequest = { viewModel.resetLoadingState() }
+                )
+
+            is UiState.Error ->
+                LaunchedEffect(key1 = Unit) {
                     snackbarHostState.showSnackbar(state.errorDescription)
                 }
-            }
-        }
-        when {
-            openConfirmationDialog.value -> {
-                // Given this dialog is open, it should be safe to say that we have successfully been given
-                // the Success UiState. We should be able to cast it to the correct object we need going forward.
-                val nameAndAccountType = loadingState.value as UiState.Success<NameAndAccountType>
 
-                UserConfirmationDialog(
-                    name = nameAndAccountType.data.name,
-                    accountType = nameAndAccountType.data.type,
-                    onDismissButtonClick = {
-                        openConfirmationDialog.value = false
-                        viewModel.resetLoadingState()
-                    },
-                    onConfirmButtonClick = {
-                        onNavigateToHomePage()
-                    },
-                    onDismissRequest = {
-                        openConfirmationDialog.value = false
-                        viewModel.resetLoadingState()
-                    }
-                )
-            }
+            else -> {}
         }
     }
 }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountAccessPageViewModel.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountAccessPageViewModel.kt
@@ -9,36 +9,61 @@ import com.sycosoft.allsee.domain.usecases.SaveTokenUseCase
 import com.sycosoft.allsee.presentation.mappers.NameAndAccountTypeMapper
 import com.sycosoft.allsee.presentation.utils.UiState
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
 
 class AccountAccessPageViewModel @Inject constructor(
     private val saveTokenUseCase: SaveTokenUseCase,
     private val getPersonUseCase: GetPersonUseCase,
 ) : ViewModel() {
-    private var _loadingState = MutableStateFlow<UiState<NameAndAccountType>>(UiState.Initial)
-    val loadingState: StateFlow<UiState<NameAndAccountType>> = _loadingState
 
-    private var _accessToken = MutableStateFlow("")
-    val accessToken: StateFlow<String> = _accessToken
+    private val nameAndAccountTypeUiState = MutableStateFlow<UiState<NameAndAccountType>>(value = UiState.Initial)
+    private val accessToken = MutableStateFlow(value = "")
+
+    val viewState: StateFlow<ViewState> by lazy {
+        combine(
+            accessToken,
+            nameAndAccountTypeUiState,
+            ::ViewState
+        ).stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Lazily,
+            initialValue = ViewState(
+                accessToken = accessToken.value,
+                nameAndAccountState = nameAndAccountTypeUiState.value
+            )
+        )
+    }
 
     fun saveToken() {
-        _loadingState.value = UiState.Loading
         viewModelScope.launch {
-            saveTokenUseCase(_accessToken.value)
-            getPerson()
+            nameAndAccountTypeUiState.update { UiState.Loading }
+            saveTokenUseCase(token = accessToken.value)
+            nameAndAccountTypeUiState.update { getPersonState() }
         }
     }
 
-    fun updateAccessToken(token: String) { _accessToken.value = token }
-
-    fun resetLoadingState() { _loadingState.value = UiState.Initial }
-
-    private suspend fun getPerson() = try {
-        _loadingState.value = UiState.Success(NameAndAccountTypeMapper.map(getPersonUseCase()))
-    } catch(e: RepositoryException) {
-        _loadingState.value = UiState.Error(e.error.error, e.error.errorDescription)
+    fun updateAccessToken(token: String) {
+        accessToken.update { token }
     }
+
+    fun resetLoadingState() {
+        nameAndAccountTypeUiState.update { UiState.Initial }
+    }
+
+    private suspend fun getPersonState() = try {
+        UiState.Success(NameAndAccountTypeMapper.map(getPersonUseCase()))
+    } catch (e: RepositoryException) {
+        UiState.Error(e.error.error, e.error.errorDescription)
+    }
+
+    data class ViewState(
+        val accessToken: String,
+        val nameAndAccountState: UiState<NameAndAccountType>
+    )
 }


### PR DESCRIPTION
## Description

- Update `AccountAccessPageViewModel` to use a mono `AccountAccessPageViewModel.ViewState` object driven by a `StateFlow<ViewState>` field.
- Update compose UI to use new `AccountAccessPageViewModel.ViewState`.  Minor simplification of the UI so it has less mutable state, and is driven by the `AccountAccessPageViewModel.ViewState`.

