### PR TITLE
feature/disable-get-started-button

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -229,6 +229,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="2001069794">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Nothing A063" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
       </map>
     </option>
   </component>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -16,6 +16,9 @@
       <SelectionState runConfigName="Tests in 'com.sycosoft.allsee'">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="AccessTokenRequestScreenTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/accountaccesspage/AccessTokenRequestScreenTest.kt
+++ b/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/accountaccesspage/AccessTokenRequestScreenTest.kt
@@ -1,6 +1,10 @@
 package com.sycosoft.allsee.presentation.components.accountaccesspage
 
 import androidx.compose.material3.Surface
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.isNotDisplayed
@@ -15,53 +19,70 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
+private typealias ATRSTT = AccessTokenRequestScreenTestTags
+
 class AccessTokenRequestScreenTest {
     @get:Rule val composeTestRule = createComposeRule()
 
+    /*
+     * =============================================================================================
+     * == Default State                                                                           ==
+     * =============================================================================================
+     */
+
     @Test
     fun whenScreenIsInDefaultState_thenEnsureCorrectComponentsAreDisplayed() {
-        // When
-        composeTestRule.setContent {
-            AllSeeTheme {
-                Surface {
-                    AccessTokenRequestScreen(
-                        accessToken = "",
-                        onAccessTokenChange = {},
-                        onButtonClick = {},
-                        showProgressBar = false,
-                    )
+
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    Surface {
+                        AccessTokenRequestScreen(
+                            accessToken = "",
+                            onAccessTokenChange = {},
+                            onButtonClick = {},
+                            showProgressBar = false,
+                        )
+                    }
                 }
             }
-        }
 
-        // Then and Verify
-        composeTestRule.onNodeWithTag(AccessTokenRequestScreenTestTags.TITLE).isDisplayed()
-        composeTestRule.onNodeWithTag(AccessTokenRequestScreenTestTags.TEXT).isDisplayed()
-        composeTestRule.onNodeWithTag(AccessTokenRequestScreenTestTags.BUTTON_GET_STARTED).isDisplayed()
-        composeTestRule.onNodeWithTag(AccessTokenRequestScreenTestTags.ACCESS_TOKEN_INPUT).isDisplayed()
-        composeTestRule.onNodeWithTag(AccessTokenRequestScreenTestTags.PROGRESS_BAR).isNotDisplayed()
+            onNodeWithTag(ATRSTT.TITLE).assertIsDisplayed()
+            onNodeWithTag(ATRSTT.TEXT).assertIsDisplayed()
+            onNodeWithTag(ATRSTT.ACCESS_TOKEN_INPUT).assertIsDisplayed()
+            onNodeWithTag(ATRSTT.BUTTON_GET_STARTED).assertIsDisplayed().assertIsNotEnabled()
+            onNodeWithTag(ATRSTT.PROGRESS_BAR).isNotDisplayed()
+        }
     }
+
+    /*
+     * =============================================================================================
+     * == Access Token Input                                                                      ==
+     * =============================================================================================
+     */
 
     @Test
     fun whenProvidedWithString_thenAccessTokenOTFShouldDisplayThatString() {
         val expected = "test_token"
 
-        // When
-        composeTestRule.setContent {
-            AllSeeTheme {
-                Surface {
-                    AccessTokenRequestScreen(
-                        accessToken = expected,
-                        onAccessTokenChange = {},
-                        onButtonClick = {},
-                        showProgressBar = false,
-                    )
+        with (composeTestRule) {
+            // When
+            setContent {
+                AllSeeTheme {
+                    Surface {
+                        AccessTokenRequestScreen(
+                            accessToken = expected,
+                            onAccessTokenChange = {},
+                            onButtonClick = {},
+                            showProgressBar = false,
+                        )
+                    }
                 }
             }
-        }
 
-        // Then and Verify
-        composeTestRule.onNodeWithTag(AccessTokenRequestScreenTestTags.ACCESS_TOKEN_INPUT).assertTextEquals(expected)
+            // Then and Verify
+            onNodeWithTag(ATRSTT.ACCESS_TOKEN_INPUT).assertTextEquals(expected)
+        }
     }
 
     @Test
@@ -69,44 +90,54 @@ class AccessTokenRequestScreenTest {
         var accessToken = ""
         val expected = "test_token"
 
-        composeTestRule.setContent {
-            AllSeeTheme {
-                Surface {
-                    AccessTokenRequestScreen(
-                        accessToken = accessToken,
-                        onAccessTokenChange = { accessToken = it },
-                        onButtonClick = {},
-                        showProgressBar = false,
-                    )
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    Surface {
+                        AccessTokenRequestScreen(
+                            accessToken = accessToken,
+                            onAccessTokenChange = { accessToken = it },
+                            onButtonClick = {},
+                            showProgressBar = false,
+                        )
+                    }
                 }
             }
+
+            onNodeWithTag(ATRSTT.ACCESS_TOKEN_INPUT).performTextInput(expected)
+
+            assertEquals(expected, accessToken)
         }
-
-        composeTestRule.onNodeWithTag(AccessTokenRequestScreenTestTags.ACCESS_TOKEN_INPUT).performTextInput(expected)
-
-        assertEquals(expected, accessToken)
     }
+
+    /*
+     * =============================================================================================
+     * == Get Started Button                                                                      ==
+     * =============================================================================================
+     */
 
     @Test
     fun whenButtonIsPressed_thenProgressBarShouldBeDisplayed() {
         var showProgressBar = false
 
-        // When
-        composeTestRule.setContent {
-            AllSeeTheme {
-                Surface {
-                    AccessTokenRequestScreen(
-                        accessToken = "",
-                        onAccessTokenChange = {},
-                        onButtonClick = { showProgressBar = true },
-                        showProgressBar = showProgressBar,
-                    )
+        with (composeTestRule) {
+            // When
+            setContent {
+                AllSeeTheme {
+                    Surface {
+                        AccessTokenRequestScreen(
+                            accessToken = "Test",
+                            onAccessTokenChange = {},
+                            onButtonClick = { showProgressBar = true },
+                            showProgressBar = showProgressBar,
+                        )
+                    }
                 }
             }
-        }
 
-        // Then and Verify
-        composeTestRule.onNodeWithTag(AccessTokenRequestScreenTestTags.BUTTON_GET_STARTED).performClick()
-        composeTestRule.onNodeWithTag(AccessTokenRequestScreenTestTags.PROGRESS_BAR).isDisplayed()
+            // Then and Verify
+            onNodeWithTag(ATRSTT.BUTTON_GET_STARTED).assertIsEnabled().performClick()
+            onNodeWithTag(ATRSTT.PROGRESS_BAR).isDisplayed()
+        }
     }
 }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/components/screens/accountaccesspage/AccessTokenRequestScreen.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/components/screens/accountaccesspage/AccessTokenRequestScreen.kt
@@ -133,6 +133,7 @@ fun AccessTokenRequestScreen(
                     bottom.linkTo(backgroundBottom.top)
                 },
             onClick = { onButtonClick() },
+            enabled = accessToken.isNotBlank(),
         ) {
             Text(text = stringResource(id = R.string.button_get_started))
         }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/theme/Color.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/theme/Color.kt
@@ -10,8 +10,10 @@ val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)
 val Pink40 = Color(0xFF7D5260)
 
-val Yellow = Color(0xFFFFEB3B)
 val ForestGreen = Color(0xFF418F45)
 val OffWhite = Color(0xFFD9D9D9)
 val NavyBlue = Color(0xFF00114D)
-val DarkBrown = Color(0xFF4D0011)
+val DarkRed = Color(0xFF4D0011)
+
+val PastelBlue = Color(0xFFDBF3FA)
+val PastelRed = Color(0xFFFF6961)

--- a/app/src/main/java/com/sycosoft/allsee/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/theme/Theme.kt
@@ -13,21 +13,21 @@ import androidx.compose.ui.platform.LocalContext
 private val DarkColorScheme = darkColorScheme(
     primary = ForestGreen,
     secondary = NavyBlue,
-    tertiary = DarkBrown,
+    tertiary = DarkRed,
     onPrimary = Color.White,
     onSecondary = Color.White,
     surface = NavyBlue,
-    inverseSurface = OffWhite,
+    inverseSurface = DarkRed,
 )
 
 private val LightColorScheme = lightColorScheme(
     primary = ForestGreen,
     secondary = NavyBlue,
-    tertiary = DarkBrown,
+    tertiary = DarkRed,
     onPrimary = Color.White,
     onSecondary = Color.White,
-    surface = OffWhite,
-    inverseSurface = NavyBlue,
+    surface = PastelBlue,
+    inverseSurface = PastelRed,
 )
 
 @Composable


### PR DESCRIPTION
## Description

This PR disables the Get Started Button in the AccessTokenRequestScreen when the access token input textfield is empty. It then re-enables the button when it's not to allow the user to progress to the next screen.

It also updates the theme of each screen to allow the disabled button to be better seen by the user (previously, you could only see half of the button).

## What is the destination of this PR?

Closes #86

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code Changes

- Modified AccessTokenRequestScreen to disable get started button when access token input is empty.
- Modified AccessTokenRequestScreenTest to check if the button is enabled or not.
- Modified Theme and Color with new colours to display to allow the button to be seen easier by the user when disabled.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Manual Testing:
    - Checked that the new theme reacts appropriately.
    - Ensure the button is disabled when input is empty.
    - Ensure the button is enabled when input is not empty.
- Component Testing:
    - Ensure the button is displayed but disabled when in default state.
    - Ensure the button is displayed and enabled when input is not empty.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
