### PR TITLE
Feature/retrieve account identifiers

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -229,6 +229,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="1550210588">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Nothing A063" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="2001069794">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -19,6 +19,9 @@
       <SelectionState runConfigName="AccessTokenRequestScreenTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="BalanceCardTests">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/androidTest/java/com/sycosoft/allsee/data/local/database/dao/AccountDaoTest.kt
+++ b/app/src/androidTest/java/com/sycosoft/allsee/data/local/database/dao/AccountDaoTest.kt
@@ -53,7 +53,11 @@ class AccountDaoTest {
                 defaultCategory = UUID.randomUUID().toString(),
                 currency = CurrencyType.GBP.ordinal,
                 createdAt = LocalDateTime.now().toString(),
-                name = "Personal"
+                name = "Personal",
+                accountIdentifier = "12345678",
+                bankIdentifier = "123456",
+                iban = "GB01234567890",
+                bic = "30456VHG"
             ),
             AccountEntity(
                 uid = expectedAccount2Uid,
@@ -61,7 +65,11 @@ class AccountDaoTest {
                 defaultCategory = UUID.randomUUID().toString(),
                 currency = CurrencyType.GBP.ordinal,
                 createdAt = LocalDateTime.now().toString(),
-                name = "Personal"
+                name = "Personal",
+                accountIdentifier = "12345678",
+                bankIdentifier = "123456",
+                iban = "GB01234567890",
+                bic = "30456VHG"
             ),
             AccountEntity(
                 uid = expectedAccount3Uid,
@@ -69,7 +77,11 @@ class AccountDaoTest {
                 defaultCategory = UUID.randomUUID().toString(),
                 currency = CurrencyType.GBP.ordinal,
                 createdAt = LocalDateTime.now().toString(),
-                name = "Personal"
+                name = "Personal",
+                accountIdentifier = "12345678",
+                bankIdentifier = "123456",
+                iban = "GB01234567890",
+                bic = "30456VHG"
             ),
         )
 
@@ -96,7 +108,11 @@ class AccountDaoTest {
                 defaultCategory = UUID.randomUUID().toString(),
                 currency = CurrencyType.GBP.ordinal,
                 createdAt = LocalDateTime.now().toString(),
-                name = "Personal"
+                name = "Personal",
+                accountIdentifier = "12345678",
+                bankIdentifier = "123456",
+                iban = "GB01234567890",
+                bic = "30456VHG"
             ),
             AccountEntity(
                 uid = expectedAccount2Uid,
@@ -104,7 +120,11 @@ class AccountDaoTest {
                 defaultCategory = UUID.randomUUID().toString(),
                 currency = CurrencyType.GBP.ordinal,
                 createdAt = LocalDateTime.now().toString(),
-                name = "Personal"
+                name = "Personal",
+                accountIdentifier = "12345678",
+                bankIdentifier = "123456",
+                iban = "GB01234567890",
+                bic = "30456VHG"
             ),
             AccountEntity(
                 uid = expectedAccount3Uid,
@@ -112,7 +132,11 @@ class AccountDaoTest {
                 defaultCategory = UUID.randomUUID().toString(),
                 currency = CurrencyType.GBP.ordinal,
                 createdAt = LocalDateTime.now().toString(),
-                name = "Personal"
+                name = "Personal",
+                accountIdentifier = "12345678",
+                bankIdentifier = "123456",
+                iban = "GB01234567890",
+                bic = "30456VHG"
             ),
         )
 

--- a/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/cards/BalanceCardTests.kt
+++ b/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/cards/BalanceCardTests.kt
@@ -1,0 +1,126 @@
+package com.sycosoft.allsee.presentation.components.cards
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.sycosoft.allsee.presentation.components.cards.balancecard.BalanceCard
+import com.sycosoft.allsee.presentation.components.cards.balancecard.BalanceCardTestTags
+import com.sycosoft.allsee.presentation.theme.AllSeeTheme
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+private typealias BCTT = BalanceCardTestTags
+
+class BalanceCardTests {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    /*
+     * =============================================================================================
+     * == Default State                                                                           ==
+     * =============================================================================================
+     */
+
+    @Test
+    fun balanceCardRendersCorrectlyWhenProvidedCorrectValues() {
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    BalanceCard(
+                        clearedBalance = "£100.00",
+                        onClick = {}
+                    )
+                }
+            }
+
+            onNodeWithTag(BCTT.BALANCE).isDisplayed()
+            onNodeWithTag(BCTT.ADD_FUNDS_ICON).isDisplayed()
+        }
+    }
+
+    /*
+     * =============================================================================================
+     * == Balance                                                                                 ==
+     * =============================================================================================
+     */
+
+    @Test
+    fun whenBalanceCardIsProvidedPositiveBalanceString_ThenEnsureItIsDisplayedCorrectly() {
+        val expected = "£100.00"
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    BalanceCard(
+                        clearedBalance = expected,
+                        onClick = {},
+                    )
+                }
+            }
+
+            onNodeWithTag(BCTT.BALANCE, useUnmergedTree = true).assertTextEquals(expected)
+        }
+    }
+
+    @Test
+    fun whenBalanceCardIsProvidedWithZeroBalanceString_ThenEnsureItIsDisplayedCorrectly() {
+        val expected = "£0.00"
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    BalanceCard(
+                        clearedBalance = expected,
+                        onClick = {},
+                    )
+                }
+            }
+
+            onNodeWithTag(BCTT.BALANCE, useUnmergedTree = true).assertTextEquals(expected)
+        }
+    }
+
+    @Test
+    fun whenBalanceCardIsProvidedWithNegativeBalanceString_ThenEnsureItIsDisplayedCorrectly() {
+        val expected = "-£100.00"
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    BalanceCard(
+                        clearedBalance = expected,
+                        onClick = {},
+                    )
+                }
+            }
+
+            onNodeWithTag(BCTT.BALANCE, useUnmergedTree = true).assertTextEquals(expected)
+        }
+    }
+
+    /*
+     * =============================================================================================
+     * == OnClick Trigger                                                                         ==
+     * =============================================================================================
+     */
+
+    @Test
+    fun whenBalanceCardIsClicked_ThenOnClickIsTriggered() {
+        var clicked = false
+        val balance = "£100.00"
+
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    BalanceCard(
+                        clearedBalance = balance,
+                        onClick = { clicked = true },
+                    )
+                }
+            }
+
+            onNodeWithText(balance).performClick()
+            assertTrue(clicked)
+        }
+    }
+}

--- a/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/homepage/HomePageScreenTest.kt
+++ b/app/src/androidTest/java/com/sycosoft/allsee/presentation/components/homepage/HomePageScreenTest.kt
@@ -19,21 +19,26 @@ class HomePageScreenTest {
     @Test
     fun whenScreenInDefaultState_thenEnsureCorrectComponentsAreDisplayed() {
         // When
-        composeTestRule.setContent {
-            AllSeeTheme {
-                Surface {
-                    HomePageScreen(
-                        accountName = "Individual",
-                        onPersonButtonClick = { /*TODO*/ },
-                        clearedBalance = "£0.00",
-                    )
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    Surface {
+                        HomePageScreen(
+                            accountName = "Individual",
+                            onPersonButtonClick = { /*TODO*/ },
+                            clearedBalance = "£0.00",
+                            onBalanceCardClick = { /* TODO */ },
+                        )
+                    }
                 }
             }
+
+            // Then and Verify
+            onNodeWithTag(HomePageScreenTestTags.ACCOUNT_NAME).isDisplayed()
+            onNodeWithTag(HomePageScreenTestTags.BUTTON_PERSON).isDisplayed()
+            onNodeWithTag(HomePageScreenTestTags.BALANCE_CARD).isDisplayed()
         }
 
-        // Then and Verify
-        composeTestRule.onNodeWithTag(HomePageScreenTestTags.ACCOUNT_NAME).isDisplayed()
-        composeTestRule.onNodeWithTag(HomePageScreenTestTags.BUTTON_PERSON).isDisplayed()
     }
 
     // #############################################################################################
@@ -44,40 +49,46 @@ class HomePageScreenTest {
     fun whenScreenInitiallyShown_thenAccountNameLabelShouldDisplayLoadingText() {
         // When
         val expected = "Loading"
-        composeTestRule.setContent {
-            AllSeeTheme {
-                Surface {
-                    HomePageScreen(
-                        accountName = null,
-                        onPersonButtonClick = {},
-                        clearedBalance = "£0.00",
-                    )
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    Surface {
+                        HomePageScreen(
+                            accountName = null,
+                            onPersonButtonClick = {},
+                            clearedBalance = "£0.00",
+                            onBalanceCardClick = { /* TODO */ },
+                        )
+                    }
                 }
             }
-        }
 
-        // Then and Verify
-        composeTestRule.onNodeWithTag(HomePageScreenTestTags.ACCOUNT_NAME).assertTextEquals(expected)
+            // Then and Verify
+            onNodeWithTag(HomePageScreenTestTags.ACCOUNT_NAME).assertTextEquals(expected)
+        }
     }
 
     @Test
     fun whenScreenLoadedWithAccountName_thenAccountNameLabelShouldDisplayValue() {
         // When
         val expected = "Individual"
-        composeTestRule.setContent {
-            AllSeeTheme {
-                Surface {
-                    HomePageScreen(
-                        accountName = expected,
-                        onPersonButtonClick = {},
-                        clearedBalance = "£0.00",
-                    )
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    Surface {
+                        HomePageScreen(
+                            accountName = expected,
+                            onPersonButtonClick = {},
+                            clearedBalance = "£0.00",
+                            onBalanceCardClick = { /* TODO */ },
+                        )
+                    }
                 }
             }
-        }
 
-        // Then and Verify
-        composeTestRule.onNodeWithTag(HomePageScreenTestTags.ACCOUNT_NAME).assertTextEquals(expected)
+            // Then and Verify
+            onNodeWithTag(HomePageScreenTestTags.ACCOUNT_NAME).assertTextEquals(expected)
+        }
     }
 
     // #############################################################################################
@@ -89,20 +100,23 @@ class HomePageScreenTest {
         // When
         var buttonClicked = false
 
-        composeTestRule.setContent {
-            AllSeeTheme {
-                Surface {
-                    HomePageScreen(
-                        accountName = null,
-                        onPersonButtonClick = { buttonClicked = true },
-                        clearedBalance = "£0.00",
-                    )
+        with (composeTestRule) {
+            setContent {
+                AllSeeTheme {
+                    Surface {
+                        HomePageScreen(
+                            accountName = null,
+                            onPersonButtonClick = { buttonClicked = true },
+                            clearedBalance = "£0.00",
+                            onBalanceCardClick = { /* TODO */ },
+                        )
+                    }
                 }
             }
-        }
 
-        // Then and Verify
-        composeTestRule.onNodeWithTag(HomePageScreenTestTags.BUTTON_PERSON).performClick()
-        assertTrue(buttonClicked)
+            // Then and Verify
+            onNodeWithTag(HomePageScreenTestTags.BUTTON_PERSON).performClick()
+            assertTrue(buttonClicked)
+        }
     }
 }

--- a/app/src/main/java/com/sycosoft/allsee/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/local/database/AppDatabase.kt
@@ -25,7 +25,7 @@ import com.sycosoft.allsee.data.local.models.PersonEntity
         AccountEntity::class,
         BalanceEntity::class,
     ], // List of entity classes that will be a part of the database.
-    version = 3 // The version of the database.
+    version = 4 // The version of the database.
 )
 abstract class AppDatabase: RoomDatabase() {
     abstract val personDao: PersonDao

--- a/app/src/main/java/com/sycosoft/allsee/data/local/models/AccountEntity.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/local/models/AccountEntity.kt
@@ -13,6 +13,10 @@ import com.sycosoft.allsee.domain.models.types.CurrencyType
  * @property currency The currency type of the account.
  * @property createdAt The date and time the account was created.
  * @property name The name of the account given by the user.
+ * @property accountIdentifier The account identifier for the account (also known as account number).
+ * @property bankIdentifier The bank identifier for the account (also known as sort code).
+ * @property iban The International Bank Account Number for the account.
+ * @property bic The Bank Identifier Code for the account.
  *
  * @see AccountType
  * @see CurrencyType
@@ -25,4 +29,8 @@ data class AccountEntity(
     @ColumnInfo(name = "currency_type") val currency: Int,
     @ColumnInfo(name = "created_at") val createdAt: String,
     @ColumnInfo(name = "account_name") val name: String,
+    @ColumnInfo(name = "account_identifier") val accountIdentifier: String,
+    @ColumnInfo(name = "bank_identifier") val bankIdentifier: String,
+    @ColumnInfo(name = "iban") val iban: String,
+    @ColumnInfo(name = "bic") val bic: String,
 )

--- a/app/src/main/java/com/sycosoft/allsee/data/remote/models/AccountIdentifierDto.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/remote/models/AccountIdentifierDto.kt
@@ -1,0 +1,15 @@
+package com.sycosoft.allsee.data.remote.models
+
+data class AccountIdentifierDto(
+    val accountIdentifier: String,
+    val accountIdentifiers: List<AccountIdentifier>,
+    val bankIdentifier: String,
+    val bic: String,
+    val iban: String
+)
+
+data class AccountIdentifier(
+    val accountIdentifier: String,
+    val bankIdentifier: String,
+    val identifierType: String
+)

--- a/app/src/main/java/com/sycosoft/allsee/data/remote/services/StarlingBankApiService.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/remote/services/StarlingBankApiService.kt
@@ -2,6 +2,7 @@ package com.sycosoft.allsee.data.remote.services
 
 import com.sycosoft.allsee.data.remote.models.AccountHolderDto
 import com.sycosoft.allsee.data.remote.models.AccountHolderNameDto
+import com.sycosoft.allsee.data.remote.models.AccountIdentifierDto
 import com.sycosoft.allsee.data.remote.models.AccountListDto
 import com.sycosoft.allsee.data.remote.models.FullBalanceDto
 import com.sycosoft.allsee.data.remote.models.IdentityDto
@@ -28,4 +29,11 @@ interface StarlingBankApiService {
     /** Requests the identity of the account holder. This is more in depth than just requesting the name. */
     @GET("identity/individual")
     suspend fun getIdentity(): IdentityDto
+
+    /** Requests the identifiers of the account.
+     *
+     * This includes the account number (account identifier), sort code (bank identifier), IBAN and BIC.
+     */
+    @GET("accounts/{accountUid}/identifiers")
+    suspend fun getAccountIdentifiers(@Path("accountUid") accountUid: String): AccountIdentifierDto
 }

--- a/app/src/main/java/com/sycosoft/allsee/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/sycosoft/allsee/data/repository/AppRepositoryImpl.kt
@@ -90,17 +90,33 @@ class AppRepositoryImpl @Inject constructor(
 
     override suspend fun getAccounts(): List<Account> = try {
         coroutineScope {
-            var accounts: List<Account> = AccountsMapper.toDomain(databaseCall { accountsDao.getAccounts() })
+            var accounts: List<Account> = AccountsMapper.toDomain(databaseCall { accountsDao.getAccounts() } )
 
             if (accounts.isEmpty()) {
-                accounts = AccountsMapper.toDomain(apiService.getAccounts())
+                val accountList = mutableListOf<Account>()
+                val accountsDto = async { apiService.getAccounts() }.await()
 
+                accountsDto.accounts.forEach { accountDto ->
+                    val identifier = async { apiService.getAccountIdentifiers(accountDto.accountUid) }.await()
+
+                    val account = AccountsMapper.toDomain(
+                        dto = accountDto,
+                        identifier = identifier,
+                    )
+
+                    accountList.add(account)
+                }
+
+                accounts = accountList
                 saveAccounts(accounts)
             }
 
             accounts
         }
-    } catch(e: ApiException) {
+
+    } catch (e: ApiException) {
+        throw throwRepositoryException(e)
+    } catch (e: DatabaseException) {
         throw throwRepositoryException(e)
     }
 

--- a/app/src/main/java/com/sycosoft/allsee/domain/mappers/AccountsMapper.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/mappers/AccountsMapper.kt
@@ -1,7 +1,8 @@
 package com.sycosoft.allsee.domain.mappers
 
 import com.sycosoft.allsee.data.local.models.AccountEntity
-import com.sycosoft.allsee.data.remote.models.AccountListDto
+import com.sycosoft.allsee.data.remote.models.AccountDto
+import com.sycosoft.allsee.data.remote.models.AccountIdentifierDto
 import com.sycosoft.allsee.domain.models.Account
 import com.sycosoft.allsee.domain.models.types.AccountType
 import com.sycosoft.allsee.domain.models.types.CurrencyType
@@ -9,16 +10,19 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 object AccountsMapper {
-    fun toDomain(dto: AccountListDto): List<Account> = dto.accounts.map { account ->
-        Account(
-            accountUid = UUID.fromString(account.accountUid),
-            accountType = AccountType.valueOf(account.accountType),
-            defaultCategory = UUID.fromString(account.defaultCategory),
-            currency = CurrencyType.valueOf(account.currency),
-            createdAt = OffsetDateTime.parse(account.createdAt),
-            name = account.name,
-        )
-    }
+
+    fun toDomain(dto: AccountDto, identifier: AccountIdentifierDto): Account = Account(
+        accountUid = UUID.fromString(dto.accountUid),
+        accountType = AccountType.valueOf(dto.accountType),
+        defaultCategory = UUID.fromString(dto.defaultCategory),
+        currency = CurrencyType.valueOf(dto.currency),
+        createdAt = OffsetDateTime.parse(dto.createdAt),
+        name = dto.name,
+        accountIdentifier = identifier.accountIdentifier,
+        bankIdentifier = identifier.bankIdentifier,
+        iban = identifier.iban,
+        bic = identifier.bic,
+    )
 
     fun toDomain(entities: List<AccountEntity>): List<Account> = entities.map { entity ->
         Account(
@@ -28,6 +32,10 @@ object AccountsMapper {
             currency = CurrencyType.entries[entity.currency],
             createdAt = OffsetDateTime.parse(entity.createdAt),
             name = entity.name,
+            accountIdentifier = entity.accountIdentifier,
+            bankIdentifier = entity.bankIdentifier,
+            iban = entity.iban,
+            bic = entity.bic,
         )
     }
 
@@ -39,17 +47,10 @@ object AccountsMapper {
             currency =  account.currency.ordinal,
             createdAt = account.createdAt.toString(),
             name = account.name,
-        )
-    }
-
-    fun toEntity(dto: AccountListDto): List<AccountEntity> = dto.accounts.map { account ->
-        AccountEntity(
-            uid = account.accountUid,
-            defaultCategory = account.defaultCategory,
-            accountType = AccountType.valueOf(account.accountType).ordinal,
-            currency = CurrencyType.valueOf(account.currency).ordinal,
-            createdAt = account.createdAt,
-            name = account.name,
+            accountIdentifier = account.accountIdentifier,
+            bankIdentifier = account.bankIdentifier,
+            iban = account.iban,
+            bic = account.bic,
         )
     }
 }

--- a/app/src/main/java/com/sycosoft/allsee/domain/models/Account.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/models/Account.kt
@@ -5,6 +5,22 @@ import com.sycosoft.allsee.domain.models.types.CurrencyType
 import java.time.OffsetDateTime
 import java.util.UUID
 
+/** Represents an account for the user.
+ *
+ * @property accountUid The unique identifier for the account, provided by the API.
+ * @property accountType The type of account.
+ * @property defaultCategory The default category for the account.
+ * @property currency The currency type for the account.
+ * @property createdAt The date and time of creation for the account.
+ * @property name The name given by the user for the account.
+ * @property accountIdentifier The identifier for the account (also known as the account number).
+ * @property bankIdentifier The identifier for the bank (also known as the sort code).
+ * @property iban The International Bank Account Number for the account.
+ * @property bic The Bank Identifier Code for the account.
+ *
+ * @see [AccountType]
+ * @see [CurrencyType]
+ */
 data class Account(
     val accountUid: UUID,
     val accountType: AccountType,
@@ -12,4 +28,8 @@ data class Account(
     val currency: CurrencyType,
     val createdAt: OffsetDateTime,
     val name: String,
+    val accountIdentifier: String,
+    val bankIdentifier: String,
+    val iban: String,
+    val bic: String,
 )

--- a/app/src/main/java/com/sycosoft/allsee/domain/repository/AppRepository.kt
+++ b/app/src/main/java/com/sycosoft/allsee/domain/repository/AppRepository.kt
@@ -40,6 +40,6 @@ interface AppRepository {
     @Throws(RepositoryException::class)
     suspend fun getIdentity(): Identity
 
-    @Throws
+    @Throws(RepositoryException::class)
     suspend fun getPerson(): Person
 }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/MainActivity.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/MainActivity.kt
@@ -25,8 +25,6 @@ class MainActivity : ComponentActivity() {
             AllSeeTheme(dynamicColor = false) {
                 Surface {
                     AppNavigation(viewModelFactory = viewModelFactory)
-                    //AccountAccessPage(viewModel = viewModel(factory = viewModelFactory))
-                    //HomePage(viewModel = viewModel(factory = viewModelFactory))
                 }
             }
         }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/components/cards/balancecard/BalanceCard.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/components/cards/balancecard/BalanceCard.kt
@@ -1,0 +1,112 @@
+package com.sycosoft.allsee.presentation.components.cards.balancecard
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.sycosoft.allsee.R
+import com.sycosoft.allsee.presentation.theme.AllSeeTheme
+import com.sycosoft.allsee.presentation.theme.Typography
+
+@Composable
+fun BalanceCard(
+    modifier: Modifier = Modifier,
+    clearedBalance: String,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = modifier
+            .padding(10.dp)
+            .clickable(
+                onClickLabel = stringResource(id = R.string.button_add_funds),
+                onClick = { onClick() }
+            )
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(
+                    top = 10.dp,
+                    bottom = 10.dp,
+                    start = 15.dp,
+                    end = 15.dp,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                modifier = Modifier.testTag(BalanceCardTestTags.BALANCE),
+                text = clearedBalance,
+                style = TextStyle(
+                    color = Typography.bodyLarge.color,
+                    fontSize = 24.sp,
+                    fontFamily = Typography.bodyLarge.fontFamily,
+                    fontWeight = FontWeight.Bold,
+                ),
+            )
+            Box(
+                modifier = Modifier
+                    .padding(start = 8.dp)
+                    .size(16.dp)
+                    .clip(CircleShape)
+                    .background(color = MaterialTheme.colorScheme.primary)
+            ) {
+                Icon(
+                    modifier = Modifier.testTag(BalanceCardTestTags.ADD_FUNDS_ICON),
+                    imageVector = Icons.Default.Add,
+                    contentDescription = stringResource(id = R.string.button_add_funds),
+                )
+            }
+        }
+    }
+}
+
+@Preview(name = "Light Mode")
+@Composable
+private fun LM_BalanceCardPreview() {
+    AllSeeTheme(dynamicColor = false) {
+        Surface {
+            BalanceCard(
+                clearedBalance = "£1,000",
+                onClick = {},
+            )
+        }
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL,
+    name = "Dark Mode"
+)
+@Composable
+private fun DM_BalanceCardPreview() {
+    AllSeeTheme(dynamicColor = false) {
+        Surface {
+            BalanceCard(
+                clearedBalance = "£1,000",
+                onClick = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/sycosoft/allsee/presentation/components/cards/balancecard/BalanceCardTestTags.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/components/cards/balancecard/BalanceCardTestTags.kt
@@ -1,0 +1,6 @@
+package com.sycosoft.allsee.presentation.components.cards.balancecard
+
+object BalanceCardTestTags {
+    const val BALANCE: String = "balance"
+    const val ADD_FUNDS_ICON: String = "add_funds_icon"
+}

--- a/app/src/main/java/com/sycosoft/allsee/presentation/components/screens/homepage/HomePageScreen.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/components/screens/homepage/HomePageScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -28,6 +27,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
+import com.sycosoft.allsee.presentation.components.cards.balancecard.BalanceCard
 import com.sycosoft.allsee.presentation.theme.AllSeeTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -38,6 +38,7 @@ fun HomePageScreen(
     accountName: String?,
     clearedBalance: String,
     onPersonButtonClick: () -> Unit,
+    onBalanceCardClick: () -> Unit,
 ) {
     val topSectionHeight = 0.90f
     val bottomSectionHeight = 0.10f
@@ -73,7 +74,7 @@ fun HomePageScreen(
         ConstraintLayout(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
+                .padding(top = innerPadding.calculateTopPadding())
         ) {
             val (
                 backgroundTop,
@@ -162,14 +163,11 @@ fun HomePageScreen(
                         .fillMaxWidth()
                         .fillMaxHeight()
                 ) {
-                    Card(
-                        modifier = Modifier.padding(start = 10.dp, end = 10.dp)
-                    ) {
-                        Text(
-                            modifier = Modifier.padding(10.dp),
-                            text = clearedBalance
-                        )
-                    }
+                    BalanceCard(
+                        modifier = Modifier.testTag(HomePageScreenTestTags.BALANCE_CARD),
+                        clearedBalance = clearedBalance,
+                        onClick = { onBalanceCardClick() }
+                    )
                 }
             }
 
@@ -200,6 +198,7 @@ private fun LM_HomePageScreenPreview() {
                 accountName = "Individual",
                 clearedBalance = "£1,000",
                 onPersonButtonClick = {},
+                onBalanceCardClick = {},
             )
         }
     }
@@ -216,6 +215,7 @@ private fun DM_HomePageScreenPreview() {
                 accountName = "Individual",
                 clearedBalance = "£1,000",
                 onPersonButtonClick = {},
+                onBalanceCardClick = {},
             )
         }
     }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/components/screens/homepage/HomePageScreenTestTags.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/components/screens/homepage/HomePageScreenTestTags.kt
@@ -5,5 +5,7 @@ object HomePageScreenTestTags {
 
     const val ACCOUNT_NAME = "account_name"
 
+    const val BALANCE_CARD = "balance_card"
+
     const val BUTTON_PERSON = "button_person"
 }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/pages/HomePage.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/pages/HomePage.kt
@@ -1,7 +1,6 @@
 package com.sycosoft.allsee.presentation.pages
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sycosoft.allsee.presentation.components.screens.homepage.HomePageScreen
@@ -10,8 +9,6 @@ import com.sycosoft.allsee.presentation.viewmodels.HomePageViewModel
 
 @Composable
 fun HomePage(viewModel: HomePageViewModel) {
-    val personDetails = viewModel.personDetails.collectAsState()
-
     val viewState by viewModel.viewState.collectAsStateWithLifecycle()
     val formatBalanceUseCase = FormatBalanceUseCase()
 
@@ -19,5 +16,6 @@ fun HomePage(viewModel: HomePageViewModel) {
         accountName = viewState.accountName,
         clearedBalance = formatBalanceUseCase(viewState.clearedBalance),
         onPersonButtonClick = {},
+        onBalanceCardClick = {},
     )
 }

--- a/app/src/main/java/com/sycosoft/allsee/presentation/theme/Color.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/theme/Color.kt
@@ -17,3 +17,4 @@ val DarkRed = Color(0xFF4D0011)
 
 val PastelBlue = Color(0xFFDBF3FA)
 val PastelRed = Color(0xFFFF6961)
+val PastelGreen = Color(0xFF80EF80)

--- a/app/src/main/java/com/sycosoft/allsee/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/theme/Theme.kt
@@ -21,7 +21,7 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = ForestGreen,
+    primary = PastelGreen,
     secondary = NavyBlue,
     tertiary = DarkRed,
     onPrimary = Color.White,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,8 @@
     <string name="user_confirmation_dialog_title">Hold on a second!</string>
     <string name="user_confirmation_dialog_text">Just to confirm, is your name %s and you hold a %s account?</string>
 
-    <string name = "button_get_started">Get Started</string>
+    <string name="button_add_funds">Add Funds</string>
+    <string name="button_get_started">Get Started</string>
     <string name="button_no">No</string>
     <string name="button_yes">Yes</string>
 

--- a/app/src/test/java/com/sycosoft/allsee/data/repository/AppRepositoryImplTest.kt
+++ b/app/src/test/java/com/sycosoft/allsee/data/repository/AppRepositoryImplTest.kt
@@ -9,20 +9,27 @@ import com.sycosoft.allsee.data.local.database.dao.BalanceDao
 import com.sycosoft.allsee.data.local.database.dao.PersonDao
 import com.sycosoft.allsee.data.local.models.PersonEntity
 import com.sycosoft.allsee.data.remote.exceptions.ApiException
+import com.sycosoft.allsee.data.remote.models.AccountDto
 import com.sycosoft.allsee.data.remote.models.AccountHolderDto
+import com.sycosoft.allsee.data.remote.models.AccountIdentifierDto
+import com.sycosoft.allsee.data.remote.models.AccountListDto
 import com.sycosoft.allsee.data.remote.models.ErrorResponseDto
 import com.sycosoft.allsee.data.remote.models.IdentityDto
 import com.sycosoft.allsee.data.remote.services.StarlingBankApiService
 import com.sycosoft.allsee.domain.exceptions.RepositoryException
 import com.sycosoft.allsee.domain.mappers.AccountHolderMapper
+import com.sycosoft.allsee.domain.mappers.AccountsMapper
 import com.sycosoft.allsee.domain.mappers.BalanceMapper
 import com.sycosoft.allsee.domain.mappers.ErrorResponseMapper
 import com.sycosoft.allsee.domain.mappers.FullBalanceMapper
 import com.sycosoft.allsee.domain.mappers.IdentityMapper
 import com.sycosoft.allsee.domain.mappers.PersonMapper
+import com.sycosoft.allsee.domain.models.Account
 import com.sycosoft.allsee.domain.models.ErrorResponse
 import com.sycosoft.allsee.domain.models.Person
 import com.sycosoft.allsee.domain.models.types.AccountHolderType
+import com.sycosoft.allsee.domain.models.types.AccountType
+import com.sycosoft.allsee.domain.models.types.CurrencyType
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -35,6 +42,7 @@ import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class AppRepositoryImplTest {
@@ -61,6 +69,18 @@ class AppRepositoryImplTest {
         email = "joe.bloggs@allsee.com",
         phone = "0192"
     )
+    private val validAccount = Account(
+        accountUid = UUID.randomUUID(),
+        accountType = AccountType.PRIMARY,
+        defaultCategory = UUID.randomUUID(),
+        currency = CurrencyType.GBP,
+        createdAt = OffsetDateTime.now(),
+        name = "Personal",
+        accountIdentifier = "12345678",
+        bankIdentifier = "123456",
+        iban = "GB12345612345678",
+        bic = "SIC1234221",
+    )
 
     @Before
     fun setUp() {
@@ -81,21 +101,42 @@ class AppRepositoryImplTest {
     }
 
     // =============================================================================================
-    // == Save Token                                                                              ==
+    // == Save Accounts                                                                           ==
     // =============================================================================================
 
     @Test
-    fun `When saveToken is called, Then it should delegate saving token to TokenProvider`() = runBlocking {
-        // When and Then
-        val token = "dummy_token"
-        underTest.saveToken(token)
+    fun `When saving accounts, Then objects should be saved and row returned`() = runBlocking {
+        val accounts: List<Account> = listOf(
+            validAccount.copy(),
+            validAccount.copy(accountUid = UUID.randomUUID()),
+            validAccount.copy(accountUid = UUID.randomUUID()),
+            validAccount.copy(accountUid = UUID.randomUUID()),
+        )
 
-        // Verify
-        coVerify { tokenProvider.saveToken(token) }
+        val expected = listOf(1L, 2L, 3L, 4L)
+        coEvery { accountsDao.insertAccounts(any()) } returns expected
+
+        val actual = underTest.saveAccounts(accounts)
+
+        coVerify(exactly = 1) { accountsDao.insertAccounts(any()) }
+        assertEquals(expected, actual)
+    }
+
+    @Test(expected = RepositoryException::class)
+    fun `When saving accounts and database throws SQLiteException, Then RepositoryException should be thrown`() = runTest {
+        coEvery { accountsDao.insertAccounts(any()) } throws SQLiteException()
+        val accounts: List<Account> = listOf(
+            validAccount.copy(),
+            validAccount.copy(accountUid = UUID.randomUUID()),
+            validAccount.copy(accountUid = UUID.randomUUID()),
+            validAccount.copy(accountUid = UUID.randomUUID()),
+        )
+
+        underTest.saveAccounts(accounts)
     }
 
     // =============================================================================================
-    // == Save Token                                                                              ==
+    // == Save Person                                                                             ==
     // =============================================================================================
 
     @Test
@@ -117,6 +158,77 @@ class AppRepositoryImplTest {
         val person = validPerson.copy()
 
         underTest.savePerson(person)
+    }
+
+    // =============================================================================================
+    // == Save Token                                                                              ==
+    // =============================================================================================
+
+    @Test
+    fun `When saveToken is called, Then it should delegate saving token to TokenProvider`() = runBlocking {
+        // When and Then
+        val token = "dummy_token"
+        underTest.saveToken(token)
+
+        // Verify
+        coVerify { tokenProvider.saveToken(token) }
+    }
+
+    // =============================================================================================
+    // == Get Accounts                                                                            ==
+    // =============================================================================================
+
+    @Test
+    fun `When API succeeds, Then accounts are returned`() = runTest {
+        val apiAccountModel = AccountDto(
+            accountUid = UUID.randomUUID().toString(),
+            accountType = AccountType.PRIMARY.name,
+            defaultCategory = UUID.randomUUID().toString(),
+            currency = CurrencyType.GBP.name,
+            createdAt = OffsetDateTime.now().toString(),
+            name = "Personal"
+        )
+        val apiAccountListDto = AccountListDto(
+            accounts = listOf(apiAccountModel),
+        )
+        val apiIdentifierModel = AccountIdentifierDto(
+            accountIdentifier = "12345678",
+            bankIdentifier = "123456",
+            iban = "GB12345612345678",
+            bic = "SIC1234221",
+            accountIdentifiers = emptyList(),
+        )
+        val expected: List<Account> = listOf(
+            AccountsMapper.toDomain(apiAccountModel, apiIdentifierModel)
+        )
+
+        coEvery { accountsDao.getAccounts() } returns emptyList()
+        coEvery { apiService.getAccountIdentifiers(any()) } returns apiIdentifierModel
+        coEvery { apiService.getAccounts() } returns apiAccountListDto
+
+        val actual = underTest.getAccounts()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `When ApiException thrown, RepositoryException should be thrown and no accounts returned`() = runTest {
+        coEvery { accountsDao.getAccounts() } returns emptyList()
+        coEvery { apiService.getAccounts() } throws apiException
+
+        try {
+            underTest.getAccounts()
+            fail("Expected RepositoryException to be thrown")
+        } catch(e: RepositoryException) {
+            assertEquals(ErrorResponseMapper.toDomain(apiException.errorResponse), e.error)
+        }
+    }
+
+    @Test(expected = RepositoryException::class)
+    fun `When DatabaseException thrown, RepositoryException should be thrown and no accounts returned`() = runTest {
+        coEvery { accountsDao.getAccounts() } throws SQLiteException()
+
+        underTest.getAccounts()
     }
 
     // =============================================================================================
@@ -178,12 +290,6 @@ class AppRepositoryImplTest {
             assertEquals(ErrorResponseMapper.toDomain(apiException.errorResponse), e.error)
         }
     }
-
-    // =============================================================================================
-    // == Get Accounts                                                                            ==
-    // =============================================================================================
-
-
 
     // =============================================================================================
     // == Get Person                                                                              ==

--- a/app/src/test/java/com/sycosoft/allsee/domain/usecases/GetAccountsUseCaseTests.kt
+++ b/app/src/test/java/com/sycosoft/allsee/domain/usecases/GetAccountsUseCaseTests.kt
@@ -33,7 +33,11 @@ class GetAccountsUseCaseTests {
             defaultCategory = UUID.randomUUID(),
             currency = CurrencyType.GBP,
             createdAt = OffsetDateTime.now(),
-            name = "Primary"
+            name = "Primary",
+            accountIdentifier = "12345678",
+            bankIdentifier = "123456",
+            iban = "GB12345612345678",
+            bic = "GB123456"
         ))
         coEvery { repository.getAccounts() } returns expected
 


### PR DESCRIPTION
## Description

This PR implements the functionality to retrieve the account identifiers from the API. Initially though, it checks to see if the information is already held within the database. If so, it returns that information. Otherwise, it pulls it from the API and then saves to the database.

## What is the destination of this PR?

Closes #93

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code Changes

- Added AccountIdentifierDto
- Modified AccountDaoTests
- Modified AccountDao
- Modified AccountsMapper
- Modified AppRepositoryImpl
- Modified StarlingBankApiService
- Modified GetAccountsUseCase
- Modified GetAccountsUseCaseTests

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Unit Testing:
    - Ensure SaveAccounts is saving properly
    - Ensure SaveAccounts returns RepositoryException on DatabaseException
    - Ensure that on DatabaseException, GetAccounts return exception to caller
    - Ensure on ApiException, GetAccounts returns exception to caller

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
