### PR TITLE
Moved NameAndAccountType to Presentation layer.

### DIFF
--- a/app/src/main/java/com/sycosoft/allsee/presentation/mappers/NameAndAccountTypeMapper.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/mappers/NameAndAccountTypeMapper.kt
@@ -1,6 +1,6 @@
 package com.sycosoft.allsee.presentation.mappers
 
-import com.sycosoft.allsee.domain.models.NameAndAccountType
+import com.sycosoft.allsee.presentation.models.NameAndAccountType
 import com.sycosoft.allsee.domain.models.Person
 
 object NameAndAccountTypeMapper {

--- a/app/src/main/java/com/sycosoft/allsee/presentation/models/NameAndAccountType.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/models/NameAndAccountType.kt
@@ -1,4 +1,4 @@
-package com.sycosoft.allsee.domain.models
+package com.sycosoft.allsee.presentation.models
 
 data class NameAndAccountType(
     val name: String,

--- a/app/src/main/java/com/sycosoft/allsee/presentation/pages/AccountAccessPage.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/pages/AccountAccessPage.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.sycosoft.allsee.domain.models.NameAndAccountType
+import com.sycosoft.allsee.presentation.models.NameAndAccountType
 import com.sycosoft.allsee.presentation.components.dialogs.UserConfirmationDialog
 import com.sycosoft.allsee.presentation.components.screens.accountaccesspage.AccessTokenRequestScreen
 import com.sycosoft.allsee.presentation.utils.UiState

--- a/app/src/main/java/com/sycosoft/allsee/presentation/usecases/GetNameAndAccountTypeUseCase.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/usecases/GetNameAndAccountTypeUseCase.kt
@@ -1,6 +1,6 @@
 package com.sycosoft.allsee.presentation.usecases
 
-import com.sycosoft.allsee.domain.models.NameAndAccountType
+import com.sycosoft.allsee.presentation.models.NameAndAccountType
 import com.sycosoft.allsee.domain.models.Person
 
 class GetNameAndAccountTypeUseCase {

--- a/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountAccessPageViewModel.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountAccessPageViewModel.kt
@@ -3,7 +3,7 @@ package com.sycosoft.allsee.presentation.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sycosoft.allsee.domain.exceptions.RepositoryException
-import com.sycosoft.allsee.domain.models.NameAndAccountType
+import com.sycosoft.allsee.presentation.models.NameAndAccountType
 import com.sycosoft.allsee.domain.usecases.GetPersonUseCase
 import com.sycosoft.allsee.domain.usecases.SaveTokenUseCase
 import com.sycosoft.allsee.presentation.mappers.NameAndAccountTypeMapper
@@ -11,7 +11,6 @@ import com.sycosoft.allsee.presentation.utils.UiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update

--- a/app/src/test/java/com/sycosoft/allsee/presentation/usecases/GetNameAndAccountTypeUseCaseTests.kt
+++ b/app/src/test/java/com/sycosoft/allsee/presentation/usecases/GetNameAndAccountTypeUseCaseTests.kt
@@ -1,6 +1,6 @@
 package com.sycosoft.allsee.presentation.usecases
 
-import com.sycosoft.allsee.domain.models.NameAndAccountType
+import com.sycosoft.allsee.presentation.models.NameAndAccountType
 import com.sycosoft.allsee.domain.models.Person
 import com.sycosoft.allsee.domain.models.types.AccountHolderType
 import junit.framework.TestCase.assertEquals


### PR DESCRIPTION
## Description

This PR moved the NameAndAccountType model from the Domain Layer to the Presentation Layer. This is because the class is only used within the Presentation Layer.

## What is the destination of this PR?

master

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
