### PR TITLE
Implement AccountDetails UseCase and Mapper

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,9 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="Tests in 'com.sycosoft.allsee'">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
       <SelectionState runConfigName="AccessTokenRequestScreenTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>

--- a/app/src/main/java/com/sycosoft/allsee/presentation/mappers/AccountDetailsMapper.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/mappers/AccountDetailsMapper.kt
@@ -1,0 +1,17 @@
+package com.sycosoft.allsee.presentation.mappers
+
+import com.sycosoft.allsee.domain.models.Account
+import com.sycosoft.allsee.domain.models.Person
+import com.sycosoft.allsee.presentation.models.AccountDetails
+
+object AccountDetailsMapper {
+    fun map(account: Account, person: Person): AccountDetails =
+        AccountDetails(
+            name = "${person.firstName} ${person.lastName}",
+            type = person.type.displayName,
+            accountNumber = account.accountIdentifier,
+            sortCode = account.bankIdentifier,
+            iban = account.iban,
+            bic = account.bic,
+        )
+}

--- a/app/src/main/java/com/sycosoft/allsee/presentation/models/AccountDetails.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/models/AccountDetails.kt
@@ -1,0 +1,10 @@
+package com.sycosoft.allsee.presentation.models
+
+data class AccountDetails(
+    val name: String,
+    val type: String,
+    val accountNumber: String,
+    val sortCode: String,
+    val iban: String,
+    val bic: String,
+)

--- a/app/src/main/java/com/sycosoft/allsee/presentation/usecases/GetAccountDetailsUseCase.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/usecases/GetAccountDetailsUseCase.kt
@@ -1,0 +1,11 @@
+package com.sycosoft.allsee.presentation.usecases
+
+import com.sycosoft.allsee.domain.models.Account
+import com.sycosoft.allsee.domain.models.Person
+import com.sycosoft.allsee.presentation.mappers.AccountDetailsMapper
+import com.sycosoft.allsee.presentation.models.AccountDetails
+
+class GetAccountDetailsUseCase {
+    operator fun invoke(account: Account, person: Person): AccountDetails =
+        AccountDetailsMapper.map(account, person)
+}

--- a/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountDetailsPageViewModel.kt
+++ b/app/src/main/java/com/sycosoft/allsee/presentation/viewmodels/AccountDetailsPageViewModel.kt
@@ -1,0 +1,10 @@
+package com.sycosoft.allsee.presentation.viewmodels
+
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+class AccountDetailsPageViewModel @Inject constructor(
+
+) : ViewModel() {
+    // TODO: Implement this along with AccountDetailsPage.
+}

--- a/app/src/test/java/com/sycosoft/allsee/presentation/usecases/GetAccountDetailsUseCaseTests.kt
+++ b/app/src/test/java/com/sycosoft/allsee/presentation/usecases/GetAccountDetailsUseCaseTests.kt
@@ -1,0 +1,63 @@
+package com.sycosoft.allsee.presentation.usecases
+
+import com.sycosoft.allsee.domain.models.Account
+import com.sycosoft.allsee.domain.models.Person
+import com.sycosoft.allsee.domain.models.types.AccountHolderType
+import com.sycosoft.allsee.domain.models.types.AccountType
+import com.sycosoft.allsee.domain.models.types.CurrencyType
+import com.sycosoft.allsee.presentation.models.AccountDetails
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class GetAccountDetailsUseCaseTests {
+    private val account = Account(
+        accountUid = UUID.randomUUID(),
+        accountType = AccountType.PRIMARY,
+        defaultCategory = UUID.randomUUID(),
+        currency = CurrencyType.GBP,
+        createdAt = OffsetDateTime.now(),
+        name = "Personal",
+        accountIdentifier = "12345678",
+        bankIdentifier = "123456",
+        iban = "GB123456789012345678",
+        bic = "ABCD12"
+    )
+    private val person = Person(
+        uid = UUID.randomUUID(),
+        type = AccountHolderType.INDIVIDUAL,
+        title = "Mr",
+        firstName = "Joe",
+        lastName = "Bloggs",
+        dob = LocalDate.parse("1975-01-01"),
+        email = "joe.blogs@example.com",
+        phone = "07932555555"
+    )
+
+    private lateinit var underTest: GetAccountDetailsUseCase
+
+    @Before
+    fun setup() {
+        underTest = GetAccountDetailsUseCase()
+    }
+
+    @Test
+    fun whenUseCaseCalled_ThenReturnsAccountDetailsObject() = runTest {
+        val expected = AccountDetails(
+            name = "${person.firstName} ${person.lastName}",
+            type = person.type.displayName,
+            accountNumber = account.accountIdentifier,
+            sortCode = account.bankIdentifier,
+            iban = account.iban,
+            bic = account.bic,
+        )
+
+        val actual = underTest(account, person)
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
## Description

This PR implements a presentation account details data class along with a mapper and its use case. This will provide the basis for the AccountDetailsPage which will be implemented soon.

## What is the destination of this PR?

Closes #96

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Code Changes

- Added AccountDetails
- Added AccountDetailsMapper
- Added GetAccountDetailsUseCase
- Added GetAccountDetailsUseCaseTests

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Unit Tests:
    -  Ensure that when the use case is used that it returns the expected object.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
