### PR TITLE
remove .idea folder from git entirely - this is for local use only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
+.idea
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
## Description

Add `.idea` folder to gitignore completely.  This is a local hidden folder for local caches and can be removed completely as different environment will update cached files in source control causing conflicts.

## What is the destination of this PR?

Fixes # (issue)

Issue with local caches being introduced into source control

## Type of change

Chore

## Code Changes

Update `.gitignore`

# How Has This Been Tested?

na
