### PR TITLE
Add a User Confirmation Dialog to the Login feature.

### DIFF
--- a/features/login/src/main/java/uk/co/jaffakree/allsee/login/presentation/components/dialogs/UserConfirmationDialog.kt
+++ b/features/login/src/main/java/uk/co/jaffakree/allsee/login/presentation/components/dialogs/UserConfirmationDialog.kt
@@ -105,7 +105,7 @@ private fun UserConfirmationDialogPreview() {
     AllSeeTheme {
         Surface {
             UserConfirmationDialog(
-                name = "Jamie Edwards",
+                name = "Joe Bloggs",
                 accountType = "Individual",
                 onDismissButtonClick = {},
                 onConfirmButtonClick = {},


### PR DESCRIPTION
This PR updates the UserConfirmationDialogTest to use a different name when testing the default display for the dialog.