### PR TITLE
add-login-screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,1 @@
-<resources>
-    <string name="app_name">AllSee</string>
-</resources>
+<resources></resources>

--- a/core/src/main/java/uk/co/jaffakree/allsee/core/presentation/theme/Type.kt
+++ b/core/src/main/java/uk/co/jaffakree/allsee/core/presentation/theme/Type.kt
@@ -14,12 +14,16 @@ val Typography = Typography(
         fontSize = 16.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
+        fontSize = 16.sp,
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Cursive,
+        fontWeight = FontWeight.Normal,
+        fontSize = 64.sp,
         lineHeight = 28.sp,
         letterSpacing = 0.sp
     ),
@@ -30,5 +34,4 @@ val Typography = Typography(
         lineHeight = 16.sp,
         letterSpacing = 0.5.sp
     )
-    */
 )

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
+    <string name="app_name">AllSee</string>
+
     <string name="button_no">No</string>
     <string name="button_yes">Yes</string>
 </resources>

--- a/features/login/src/androidTest/java/uk/co/jaffakree/allsee/login/presentation/screen/LoginScreenTest.kt
+++ b/features/login/src/androidTest/java/uk/co/jaffakree/allsee/login/presentation/screen/LoginScreenTest.kt
@@ -1,0 +1,189 @@
+package uk.co.jaffakree.allsee.login.presentation.screen
+
+import android.content.Context
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasImeAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.text.input.ImeAction
+import androidx.test.core.app.ApplicationProvider
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import uk.co.jaffakree.allsee.login.R
+
+class LoginScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+// region Normal Mode
+
+    @Test
+    fun whenNormallyDisplayed_thenQuestionScreenShown() {
+        with (composeTestRule) {
+            setContent {
+                LoginScreen(
+                    accessToken = "",
+                    onAccessTokenChange = {},
+                    showProgressBar = false,
+                    onLoginButtonClick = {},
+                )
+            }
+
+            with (LoginScreenTestTags) {
+                onNodeWithTag(COMPONENT).assertIsDisplayed()
+
+                onNodeWithTag(TEXT_TITLE)
+                    .assertIsDisplayed()
+                    .assertTextEquals(context.getString(R.string.title))
+
+                onNodeWithTag(TEXT_GET_STARTED)
+                    .assertIsDisplayed()
+                    .assertTextEquals(context.getString(R.string.get_started))
+
+                onNodeWithTag(TEXT_FIELD_ACCESS_TOKEN)
+                    .assertIsDisplayed()
+                    .assertTextContains(context.getString(R.string.access_token))
+            }
+        }
+    }
+
+// endregion
+// region Access Token Text Field
+
+    @Test
+    fun whenProvidedWithString_thenAccessTokenInputShouldUpdate() {
+        val expected = "Test Access Token"
+        with (composeTestRule) {
+            setContent {
+                LoginScreen(
+                    accessToken = expected,
+                    onAccessTokenChange = {},
+                    showProgressBar = false,
+                    onLoginButtonClick = {}
+                )
+            }
+
+            with (LoginScreenTestTags) {
+                onNodeWithTag(COMPONENT).assertIsDisplayed()
+
+                onNodeWithTag(TEXT_FIELD_ACCESS_TOKEN)
+                    .assertIsDisplayed()
+                    .assertTextContains(expected)
+            }
+        }
+    }
+
+    @Test
+    fun whenAccessTokenIsChanged_thenInputShouldUpdate() {
+        val expected = "Test Access Token"
+        var actual = ""
+
+        with (composeTestRule) {
+            setContent {
+                LoginScreen(
+                    accessToken = actual,
+                    onAccessTokenChange = { actual = it },
+                    showProgressBar = false,
+                    onLoginButtonClick = {}
+                )
+            }
+
+            with (LoginScreenTestTags) {
+                onNodeWithTag(COMPONENT).assertIsDisplayed()
+
+                onNodeWithTag(TEXT_FIELD_ACCESS_TOKEN)
+                    .assertIsDisplayed()
+                    .performTextInput(expected)
+
+                assertEquals(expected, actual)
+            }
+        }
+    }
+
+    @Test
+    fun whenKeyboardEnterIsPressedOnAccessTokenInput_thenDoneImeActionShouldBePresent() {
+        with (composeTestRule) {
+            setContent {
+                LoginScreen(
+                    accessToken = "",
+                    onAccessTokenChange = {},
+                    showProgressBar = false,
+                    onLoginButtonClick = {}
+                )
+            }
+
+            with (LoginScreenTestTags) {
+                onNodeWithTag(COMPONENT).assertIsDisplayed()
+
+                onNodeWithTag(TEXT_FIELD_ACCESS_TOKEN)
+                    .assert(hasImeAction(ImeAction.Done))
+            }
+        }
+    }
+
+// endregion
+// region Button Tests
+
+    @Test
+    fun whenLoginButtonClicked_thenOnLoginButtonClickIsCalled() {
+        var clicked = false
+
+        with (composeTestRule) {
+            setContent {
+                LoginScreen(
+                    accessToken = "",
+                    onAccessTokenChange = {},
+                    showProgressBar = false,
+                    onLoginButtonClick = { clicked = true }
+                )
+            }
+
+            with (LoginScreenTestTags) {
+                onNodeWithTag(COMPONENT).assertIsDisplayed()
+
+                onNodeWithTag(BUTTON_LOGIN)
+                    .performClick()
+
+                assertTrue(clicked)
+            }
+        }
+    }
+
+// endregion
+// region Logging In Mode
+
+    @Test
+    fun whenShowProgressBarIsSet_thenLoggingInScreenShown() {
+        with (composeTestRule) {
+            setContent {
+                LoginScreen(
+                    accessToken = "",
+                    onAccessTokenChange = {},
+                    showProgressBar = true,
+                    onLoginButtonClick = {}
+                )
+            }
+
+            with (LoginScreenTestTags) {
+                onNodeWithTag(COMPONENT).assertIsDisplayed()
+
+                onNodeWithTag(PROGRESS_BAR).assertIsDisplayed()
+
+                onNodeWithTag(TEXT_LOGGING_IN)
+                    .assertIsDisplayed()
+                    .assertTextEquals(context.getString(R.string.logging_in))
+            }
+        }
+    }
+
+// endregion
+}

--- a/features/login/src/main/java/uk/co/jaffakree/allsee/login/presentation/screen/LoginScreen.kt
+++ b/features/login/src/main/java/uk/co/jaffakree/allsee/login/presentation/screen/LoginScreen.kt
@@ -1,0 +1,158 @@
+package uk.co.jaffakree.allsee.login.presentation.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import uk.co.jaffakree.allsee.core.presentation.theme.AllSeeTheme
+import uk.co.jaffakree.allsee.login.R
+
+internal object LoginScreenTestTags {
+    const val COMPONENT = "login_screen"
+
+    const val BUTTON_LOGIN = "${COMPONENT}_button_login"
+    const val BUTTON_LOGIN_TEXT = "${BUTTON_LOGIN}_text"
+
+    const val PROGRESS_BAR = "${COMPONENT}_progress_bar"
+
+    const val TEXT_FIELD_ACCESS_TOKEN = "${COMPONENT}_text_field_access_token"
+
+    const val TEXT_GET_STARTED = "${COMPONENT}_text_get_started"
+    const val TEXT_LOGGING_IN = "${COMPONENT}_text_logging_in"
+    const val TEXT_TITLE = "${COMPONENT}_text_title"
+}
+
+@Composable
+internal fun LoginScreen(
+    accessToken: String,
+    onAccessTokenChange: (String) -> Unit,
+    showProgressBar: Boolean,
+    onLoginButtonClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .testTag(LoginScreenTestTags.COMPONENT)
+            .fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        if (showProgressBar) {
+            ProgressBarContent()
+        } else {
+            QuestionContent(
+                accessToken = accessToken,
+                onAccessTokenChange = { onAccessTokenChange(it) },
+                onLoginButtonClick = { onLoginButtonClick() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuestionContent(
+    accessToken: String,
+    onAccessTokenChange: (String) -> Unit,
+    onLoginButtonClick: () -> Unit,
+) {
+    Text(
+        modifier = Modifier
+            .testTag(LoginScreenTestTags.TEXT_TITLE)
+            .padding(32.dp),
+        text = stringResource(R.string.title),
+        style = MaterialTheme.typography.titleLarge,
+    )
+    Text(
+        modifier = Modifier
+            .testTag(LoginScreenTestTags.TEXT_GET_STARTED),
+        text = stringResource(R.string.get_started)
+    )
+    OutlinedTextField(
+        modifier = Modifier
+            .testTag(LoginScreenTestTags.TEXT_FIELD_ACCESS_TOKEN)
+            .padding(top = 64.dp, bottom = 16.dp),
+        value = accessToken,
+        singleLine = true,
+        onValueChange = { onAccessTokenChange(it) },
+        placeholder = {
+            Text(
+                text = stringResource(R.string.access_token)
+            )
+        },
+        keyboardOptions = KeyboardOptions.Default.copy(
+            imeAction = ImeAction.Done,
+        )
+    )
+    Button(
+        modifier = Modifier
+            .testTag(LoginScreenTestTags.BUTTON_LOGIN),
+        onClick = { onLoginButtonClick() },
+    ) {
+        Text(
+            modifier = Modifier
+                .testTag(LoginScreenTestTags.BUTTON_LOGIN_TEXT),
+            text = stringResource(R.string.button_login),
+        )
+    }
+}
+
+@Composable
+private fun ProgressBarContent() {
+    CircularProgressIndicator(
+        modifier = Modifier
+            .testTag(LoginScreenTestTags.PROGRESS_BAR)
+    )
+    Text(
+        modifier = Modifier
+            .testTag(LoginScreenTestTags.TEXT_LOGGING_IN),
+        text = stringResource(R.string.logging_in)
+    )
+}
+
+// region Previews
+
+@PreviewLightDark
+@Composable
+fun LoginScreenPreview() {
+    AllSeeTheme {
+        Surface {
+            LoginScreen(
+                accessToken = "",
+                onAccessTokenChange = {},
+                showProgressBar = false,
+                onLoginButtonClick = {}
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+fun LoginScreenWithProgressBarPreview() {
+    AllSeeTheme {
+        Surface {
+            LoginScreen(
+                accessToken = "",
+                onAccessTokenChange = {},
+                showProgressBar = true,
+                onLoginButtonClick = {}
+            )
+        }
+    }
+}
+
+// endregion

--- a/features/login/src/main/res/values/strings.xml
+++ b/features/login/src/main/res/values/strings.xml
@@ -1,7 +1,11 @@
 <resources>
-    <string name="aap_access_token">Access Token</string>
-    <string name="aap_get_started">To get started, paste your access token below.</string>
-    <string name="aap_title">Oh, hey!</string>
+
+    <string name="button_login">Login</string>
+
+    <string name="access_token">Access Token</string>
+    <string name="get_started">To get started, paste your access token below.</string>
+    <string name="logging_in">Logging in…</string>
+    <string name="title">Oh, hey!</string>
 
     <string name="user_confirmation_dialog_title">Hold on a second!</string>
     <string name="user_confirmation_dialog_text">Just to confirm, is your name %s and you hold a %s account?</string>


### PR DESCRIPTION
## Description

This PR adds a Login Screen which asks the user to provide an access token for their account. 

## Tests

- Component Tests
    - When normally displayed, then question screen shown
    - When provided with string, then access token input should update
    - When access token is changed, then input should update
    - When keyboard enter is pressed on access token input, then done IME action should be present
    - When login button clicked, then on login button click is called
    - When showProgressBar is set, then logging in screen shown

## Screenshots

### Normal Mode

| Dark Mode | Light Mode |
| ---------------- | ----------------  |
| ![image](https://github.com/user-attachments/assets/3e970a31-6f89-48fe-995f-93ba64efb792) | ![image](https://github.com/user-attachments/assets/6afca80b-684f-4bbd-ab2e-264e88988c9f) |

### Logging In Mode

| Dark Mode | Light Mode |
| ---------------- | ----------------  |
| ![image](https://github.com/user-attachments/assets/978b23c7-b8d1-498d-9a51-f887fb2c1a4b) | ![image](https://github.com/user-attachments/assets/a2d583a4-f82f-47fa-8ffe-bea338fe8e22) |